### PR TITLE
Make first news item larger

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,6 +6,8 @@
   --color-surface: #FFFFFF;
   --text-primary: #2C3E50;
   --text-muted: #7F8C8D;
+  --tile-width: 12rem;
+  --tile-image-height: 7.5rem;
 }
 
 body {
@@ -42,15 +44,23 @@ nav a:hover {
 .news-tile {
   background-color: var(--color-surface);
   border: 1px solid var(--text-muted);
-  width: 200px;
+  width: var(--tile-width);
   cursor: pointer;
   padding: 0.5rem;
 }
 
+.news-tile:first-child {
+  width: calc(var(--tile-width) * 4);
+}
+
 .news-tile img {
   width: 100%;
-  height: 120px;
+  height: var(--tile-image-height);
   object-fit: cover;
+}
+
+.news-tile:first-child img {
+  height: calc(var(--tile-image-height) * 4);
 }
 
 .news-tile p {


### PR DESCRIPTION
## Summary
- emphasize the first news tile with CSS variables
- ensure first tile image height uses the expanded value by moving the rule after the general selector

## Testing
- `npm test` *(fails: Cannot find module 'karma')*

------
https://chatgpt.com/codex/tasks/task_e_684eef37f3508329bc90c22007cbc9a2