### PR TITLE
Add hover style to news items

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,7 +1,9 @@
 <div class="news-list">
   <div class="news-tile" *ngFor="let item of newsList" (click)="openNews(item.id)">
-    <img [src]="item.image" alt="{{item.title}}">
-    <h3>{{item.title}}</h3>
+    <div class="image-container">
+      <img [src]="item.image" alt="{{item.title}}">
+      <h3 class="image-title">{{item.title}}</h3>
+    </div>
     <p>{{item.preview}}</p>
   </div>
 </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -49,6 +49,26 @@ nav a:hover {
   padding: 0.5rem;
 }
 
+.news-tile .image-container {
+  position: relative;
+}
+
+.news-tile .image-title {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+  color: var(--color-surface);
+  background-color: rgba(44, 62, 80, 0.7); /* color-primary with transparency */
+}
+
+.news-tile:hover {
+  background-color: var(--color-background);
+}
+
 .news-tile:first-child {
   width: calc(var(--tile-width) * 4);
 }


### PR DESCRIPTION
## Summary
- change news tile background on hover to a gray tone from the palette
- overlay news titles on top of images on the home page

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684ef4d86a008329aab0eee812ddc1ff