### PR TITLE
Add Vienna local news page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,10 @@ import { FooterComponent } from './components/footer/footer.component';
 import { HomeComponent } from './components/home/home.component';
 import { NewsDetailComponent } from './components/news-detail/news-detail.component';
 import { NewsService } from './services/news.service';
+import { NewsCardComponent } from './components/news-card/news-card.component';
+import { TopStoriesComponent } from './components/top-stories/top-stories.component';
+import { ViennaNewsComponent } from './components/vienna-news/vienna-news.component';
+import { LocalNewsDetailComponent } from './components/local-news-detail/local-news-detail.component';
 
 @NgModule({
   declarations: [
@@ -14,13 +18,19 @@ import { NewsService } from './services/news.service';
     HeaderComponent,
     FooterComponent,
     HomeComponent,
-    NewsDetailComponent
+    NewsDetailComponent,
+    NewsCardComponent,
+    TopStoriesComponent,
+    ViennaNewsComponent,
+    LocalNewsDetailComponent
   ],
   imports: [
     BrowserModule,
     RouterModule.forRoot([
       { path: '', component: HomeComponent },
-      { path: 'news/:id', component: NewsDetailComponent }
+      { path: 'news/:id', component: NewsDetailComponent },
+      { path: 'local-news/vienna', component: ViennaNewsComponent },
+      { path: 'local-news/vienna/:id', component: LocalNewsDetailComponent }
     ])
   ],
   providers: [NewsService],

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -19,6 +19,7 @@
       <a href="#">Lifestyle</a>
       <a href="#">Tech</a>
       <a href="#">Opinion</a>
+      <a routerLink="/local-news/vienna">Vienna</a>
     </nav>
 
     <button class="tiktok-btn" aria-label="TikTok">

--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -1,0 +1,5 @@
+<div class="local-news-detail" *ngIf="article">
+  <h2>{{article.title}}</h2>
+  <img [src]="article.image_url" alt="{{article.title}}">
+  <p>{{article.content}}</p>
+</div>

--- a/src/app/components/local-news-detail/local-news-detail.component.scss
+++ b/src/app/components/local-news-detail/local-news-detail.component.scss
@@ -1,0 +1,8 @@
+.local-news-detail {
+  padding: 1rem;
+}
+
+.local-news-detail img {
+  max-width: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/app/components/local-news-detail/local-news-detail.component.ts
+++ b/src/app/components/local-news-detail/local-news-detail.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LocalNewsArticle, LocalNewsService } from '../../services/local-news.service';
+
+@Component({
+  selector: 'app-local-news-detail',
+  templateUrl: './local-news-detail.component.html',
+  styleUrls: ['./local-news-detail.component.scss']
+})
+export class LocalNewsDetailComponent implements OnInit {
+  article?: LocalNewsArticle;
+
+  constructor(private route: ActivatedRoute, private router: Router, private service: LocalNewsService) {}
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    this.article = this.service.getViennaNewsById(id);
+    if (!this.article) {
+      this.router.navigate(['/local-news/vienna']);
+    }
+  }
+}

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -1,0 +1,10 @@
+<div class="news-card" (click)="open()">
+  <div class="image-wrapper">
+    <img [src]="article.image_url" alt="{{article.title}}" />
+  </div>
+  <div class="card-body">
+    <h3 class="title">{{article.title}}</h3>
+    <p class="summary">{{article.summary}}</p>
+    <small class="meta">{{article.category}} | {{article.published_at}}</small>
+  </div>
+</div>

--- a/src/app/components/news-card/news-card.component.scss
+++ b/src/app/components/news-card/news-card.component.scss
@@ -1,0 +1,59 @@
+.news-card {
+  background: #fff;
+  border: 1px solid #dee2e6;
+  overflow: hidden;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.image-wrapper {
+  position: relative;
+  overflow: hidden;
+  padding-top: 56.25%;
+}
+
+.image-wrapper img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.news-card:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.news-card:hover .image-wrapper img {
+  transform: scale(1.05);
+}
+
+.card-body {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #d62828;
+  margin: 0;
+}
+
+.summary {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.meta {
+  font-size: 0.75rem;
+  color: #6c757d;
+}

--- a/src/app/components/news-card/news-card.component.ts
+++ b/src/app/components/news-card/news-card.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { LocalNewsArticle } from '../../services/local-news.service';
+
+@Component({
+  selector: 'app-news-card',
+  templateUrl: './news-card.component.html',
+  styleUrls: ['./news-card.component.scss']
+})
+export class NewsCardComponent {
+  @Input() article!: LocalNewsArticle;
+
+  constructor(private router: Router) {}
+
+  open() {
+    this.router.navigate(['/local-news/vienna', this.article.id]);
+  }
+}

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -1,0 +1,6 @@
+<div class="top-stories">
+  <div class="story" *ngFor="let s of stories" (click)="open(s)">
+    <img [src]="s.image_url" alt="{{s.title}}" />
+    <h2>{{s.title}}</h2>
+  </div>
+</div>

--- a/src/app/components/top-stories/top-stories.component.scss
+++ b/src/app/components/top-stories/top-stories.component.scss
@@ -1,0 +1,36 @@
+.top-stories {
+  display: flex;
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.story {
+  position: relative;
+  flex: 1;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.story img {
+  width: 100%;
+  height: 12rem;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.story h2 {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(33, 37, 41, 0.6);
+  color: #fff;
+  font-size: 1.5rem;
+}
+
+.story:hover img {
+  transform: scale(1.05);
+}

--- a/src/app/components/top-stories/top-stories.component.ts
+++ b/src/app/components/top-stories/top-stories.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { LocalNewsArticle } from '../../services/local-news.service';
+
+@Component({
+  selector: 'app-top-stories',
+  templateUrl: './top-stories.component.html',
+  styleUrls: ['./top-stories.component.scss']
+})
+export class TopStoriesComponent {
+  @Input() stories: LocalNewsArticle[] = [];
+
+  constructor(private router: Router) {}
+
+  open(article: LocalNewsArticle) {
+    this.router.navigate(['/local-news/vienna', article.id]);
+  }
+}

--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -1,0 +1,15 @@
+<div class="page">
+  <h1 class="page-title">Vienna Local News</h1>
+  <app-top-stories [stories]="topStories"></app-top-stories>
+  <div class="content-grid">
+    <div class="news-feed">
+      <app-news-card *ngFor="let n of feed" [article]="n"></app-news-card>
+    </div>
+    <aside class="sidebar">
+      <div class="weather-widget">
+        <h3>Vienna Weather</h3>
+        <p>18°C &ndash; Sunny</p>
+      </div>
+    </aside>
+  </div>
+</div>

--- a/src/app/components/vienna-news/vienna-news.component.scss
+++ b/src/app/components/vienna-news/vienna-news.component.scss
@@ -1,0 +1,49 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+.page {
+  font-family: 'Inter', sans-serif;
+  background: #f8f9fa;
+  color: #212529;
+  padding: 1rem;
+}
+
+.page-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #d62828;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+
+.news-feed {
+  grid-column: span 8;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.sidebar {
+  grid-column: span 4;
+}
+
+.weather-widget {
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #dee2e6;
+  position: sticky;
+  top: 1rem;
+}
+
+@media (max-width: 768px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+  .news-feed, .sidebar {
+    grid-column: span 12;
+  }
+}

--- a/src/app/components/vienna-news/vienna-news.component.ts
+++ b/src/app/components/vienna-news/vienna-news.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { LocalNewsArticle, LocalNewsService } from '../../services/local-news.service';
+
+@Component({
+  selector: 'app-vienna-news',
+  templateUrl: './vienna-news.component.html',
+  styleUrls: ['./vienna-news.component.scss']
+})
+export class ViennaNewsComponent implements OnInit {
+  topStories: LocalNewsArticle[] = [];
+  feed: LocalNewsArticle[] = [];
+
+  constructor(private localNews: LocalNewsService) {}
+
+  ngOnInit(): void {
+    const all = this.localNews.getViennaNews();
+    this.topStories = all.slice(0, 3);
+    this.feed = all.slice(3);
+  }
+}

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -38,7 +38,7 @@ export class LocalNewsService {
       id: 3,
       title: 'Concert Series Returns to Stephansplatz',
       summary: 'Open-air concerts will resume this summer with local bands.',
-      image_url: 'assets/vienna/concert.jpg',
+      image_url: 'assets/vienna/concert.webp',
       category: 'Entertainment',
       published_at: '2024-05-15',
       read_more_url: '#',

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@angular/core';
+
+export interface LocalNewsArticle {
+  id: number;
+  title: string;
+  summary: string;
+  image_url: string;
+  category: string;
+  published_at: string;
+  read_more_url: string;
+  content: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LocalNewsService {
+  private viennaNews: LocalNewsArticle[] = [
+    {
+      id: 1,
+      title: 'Vienna Street Festival Draws Thousands',
+      summary: 'Residents flock to the annual street festival in the heart of Vienna.',
+      image_url: 'assets/vienna/street-festival.jpg',
+      category: 'Culture',
+      published_at: '2024-05-10',
+      read_more_url: '#',
+      content: 'Full article about the vibrant street festival taking place in Vienna...'
+    },
+    {
+      id: 2,
+      title: 'New Tram Line Opens in the 7th District',
+      summary: 'The city introduces a new tram line improving connectivity.',
+      image_url: 'assets/vienna/tram.jpg',
+      category: 'Local',
+      published_at: '2024-05-12',
+      read_more_url: '#',
+      content: 'Article covering the inauguration of the new tram line...'
+    },
+    {
+      id: 3,
+      title: 'Concert Series Returns to Stephansplatz',
+      summary: 'Open-air concerts will resume this summer with local bands.',
+      image_url: 'assets/vienna/concert.jpg',
+      category: 'Entertainment',
+      published_at: '2024-05-15',
+      read_more_url: '#',
+      content: 'Details on the upcoming concert series in Stephansplatz...'
+    },
+    {
+      id: 4,
+      title: 'Vienna Zoo Welcomes Baby Panda',
+      summary: 'Exciting news as the zoo announces the birth of a panda cub.',
+      image_url: 'assets/vienna/panda.jpg',
+      category: 'Animals',
+      published_at: '2024-05-17',
+      read_more_url: '#',
+      content: 'More information about the new addition to the Vienna Zoo...'
+    },
+    {
+      id: 5,
+      title: 'City Council Approves New Cycling Lanes',
+      summary: 'More cycling lanes aim to make Vienna a bike-friendly city.',
+      image_url: 'assets/vienna/cycling.jpg',
+      category: 'Infrastructure',
+      published_at: '2024-05-20',
+      read_more_url: '#',
+      content: 'Everything about the expansion of cycling infrastructure...'
+    },
+    {
+      id: 6,
+      title: 'Local Market Showcases Organic Produce',
+      summary: 'Farmers market highlights locally sourced organic goods.',
+      image_url: 'assets/vienna/market.jpg',
+      category: 'Lifestyle',
+      published_at: '2024-05-22',
+      read_more_url: '#',
+      content: 'Article on the growing trend of organic produce in Vienna...'
+    },
+    {
+      id: 7,
+      title: 'Technology Hub Opens Near Donau City',
+      summary: 'A new technology hub promises innovation and jobs.',
+      image_url: 'assets/vienna/tech-hub.jpg',
+      category: 'Business',
+      published_at: '2024-05-25',
+      read_more_url: '#',
+      content: 'Coverage of the opening ceremony of the tech hub...'
+    },
+    {
+      id: 8,
+      title: 'Historic Coffee House Gets Renovated',
+      summary: 'Beloved coffee house reopens its doors after extensive renovation.',
+      image_url: 'assets/vienna/coffee-house.jpg',
+      category: 'Culture',
+      published_at: '2024-05-27',
+      read_more_url: '#',
+      content: 'Insights into the renovation and history of the coffee house...'
+    },
+    {
+      id: 9,
+      title: 'Rainy Week Ahead, Says Forecast',
+      summary: 'Meteorologists predict a wet week for Vienna residents.',
+      image_url: 'assets/vienna/rain.jpg',
+      category: 'Weather',
+      published_at: '2024-05-30',
+      read_more_url: '#',
+      content: 'Full forecast details and tips for staying dry...'
+    }
+  ];
+
+  getViennaNews(): LocalNewsArticle[] {
+    return this.viennaNews;
+  }
+
+  getViennaNewsById(id: number): LocalNewsArticle | undefined {
+    return this.viennaNews.find(n => n.id === id);
+  }
+}

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -14,8 +14,8 @@ export class NewsService {
       title: 'Sunny Weather Expected Tomorrow',
       preview: 'Meteorologists predict sunny skies',
       content: 'Detailed weather forecast goes here...',
-      image: 'assets/weather.jpg',
-      bigImage: 'assets/weather_big.jpg'
+      image: 'assets/sunny.jpg',
+      bigImage: 'assets/sunny.jpg'
     },
     {
       id: 2,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,8 +10,10 @@
   --tile-image-height: 7.5rem;
 }
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', Arial, sans-serif;
   margin: 0;
   padding: 0;
   background-color: var(--color-background);
@@ -22,6 +24,12 @@ header, footer {
   background-color: var(--color-primary);
   color: var(--color-surface);
   padding: 1rem;
+}
+
+header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 nav a {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -54,7 +54,6 @@ nav a:hover {
   border: 1px solid var(--text-muted);
   width: var(--tile-width);
   cursor: pointer;
-  padding: 0.5rem;
 }
 
 .news-tile .image-container {
@@ -66,7 +65,6 @@ nav a:hover {
   bottom: 0;
   left: 0;
   margin: 0;
-  padding: 0.25rem 0.5rem;
   width: 100%;
   box-sizing: border-box;
   color: var(--color-surface);


### PR DESCRIPTION
## Summary
- add service for Vienna news data
- add NewsCard, TopStories, and ViennaNews components
- implement LocalNewsDetail component
- wire up new routes in `AppModule`
- tweak global styles for fonts and sticky header
- include placeholder images for Vienna news
- remove Vienna placeholder images

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module 'karma')*


------
https://chatgpt.com/codex/tasks/task_e_684f15ecff7c8329a7f27bc1ef0a9680