### PR TITLE
Add Firebase Hosting configuration

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "your-project-id"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ This is a simple Angular application that displays news articles from a dummy se
    ```
 
 The application is structured with reusable components and a `NewsService` that returns mock data. It is ready for future extension to load data from an external API.
+
+## Deployment with Firebase Hosting
+
+1. Install the Firebase CLI globally (if not already installed):
+   ```bash
+   npm install -g firebase-tools
+   ```
+2. Update `.firebaserc` with your Firebase project ID.
+3. Build and deploy the application:
+   ```bash
+   npm run deploy
+   ```

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,9 @@
+{
+  "hosting": {
+    "public": "dist/news-app",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {"source": "**", "destination": "/index.html"}
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "ng serve",
     "build": "ng build",
-    "test": "ng test"
+    "test": "ng test",
+    "deploy": "npm run build && npx firebase deploy"
   },
   "dependencies": {
     "@angular/animations": "~17.0.0",
@@ -24,6 +25,7 @@
     "@angular-devkit/build-angular": "~17.0.0",
     "@angular/cli": "~17.0.0",
     "@angular/compiler-cli": "~17.0.0",
-    "typescript": "~5.2.0"
+    "typescript": "~5.2.0",
+    "firebase-tools": "^12.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Firebase Hosting config files
- ignore node_modules and lockfile
- include deployment instructions in README
- add deploy script and firebase-tools dependency

## Testing
- `npm test` *(fails: Cannot find module 'karma')*

------
https://chatgpt.com/codex/tasks/task_e_6860576a193883298dbf89d4be7bc0c7