### PR TITLE
Add creation date and view count to news items

### DIFF
--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -1,5 +1,6 @@
 <div class="local-news-detail" *ngIf="article">
   <h2>{{article.title}}</h2>
   <img [src]="article.image_url" alt="{{article.title}}">
+  <p class="meta">Added: {{article.created_at}} | Views: {{article.views}}</p>
   <p>{{article.content}}</p>
 </div>

--- a/src/app/components/local-news-detail/local-news-detail.component.scss
+++ b/src/app/components/local-news-detail/local-news-detail.component.scss
@@ -6,3 +6,8 @@
   max-width: 100%;
   margin-bottom: 1rem;
 }
+
+.meta {
+  font-size: 0.875rem;
+  color: #6c757d;
+}

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -8,5 +8,8 @@
     <small class="meta" *ngIf="article.category">
       {{article.category}} | {{article.published_at}}
     </small>
+    <small class="meta" *ngIf="article.created_at || article.views !== undefined">
+      Added: {{article.created_at}} | Views: {{article.views}}
+    </small>
   </div>
 </div>

--- a/src/app/components/news-detail/news-detail.component.html
+++ b/src/app/components/news-detail/news-detail.component.html
@@ -1,5 +1,6 @@
 <div class="news-detail" *ngIf="news">
   <h2>{{news.title}}</h2>
   <img [src]="news.bigImage || news.image" alt="{{news.title}}">
+  <p class="meta">Added: {{news.created_at}} | Views: {{news.views}}</p>
   <p>{{news.content}}</p>
 </div>

--- a/src/app/components/news-detail/news-detail.component.scss
+++ b/src/app/components/news-detail/news-detail.component.scss
@@ -1,1 +1,5 @@
 /* additional detail styles */
+.meta {
+  font-size: 0.875rem;
+  color: #6c757d;
+}

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -2,5 +2,6 @@
   <div class="story" *ngFor="let s of stories" (click)="open(s)">
     <img [src]="s.image_url || s.image" alt="{{s.title}}" />
     <h2>{{s.title}}</h2>
+    <small class="story-meta">Added: {{s.created_at}} | Views: {{s.views}}</small>
   </div>
 </div>

--- a/src/app/components/top-stories/top-stories.component.scss
+++ b/src/app/components/top-stories/top-stories.component.scss
@@ -35,3 +35,14 @@
 .story:hover img {
   transform: scale(1.05);
 }
+
+.story-meta {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0.25rem 0.5rem;
+  background: rgba(33, 37, 41, 0.6);
+  color: #fff;
+  font-size: 0.75rem;
+}

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -7,6 +7,8 @@ export interface LocalNewsArticle {
   image_url: string;
   category: string;
   published_at: string;
+  created_at: string;
+  views: number;
   read_more_url: string;
   content: string;
 }
@@ -21,6 +23,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=11',
       category: 'Culture',
       published_at: '2024-05-10',
+      created_at: '2024-05-10',
+      views: 34,
       read_more_url: '#',
       content: 'Full article about the vibrant street festival taking place in Vienna...'
     },
@@ -31,6 +35,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=12',
       category: 'Local',
       published_at: '2024-05-12',
+      created_at: '2024-05-12',
+      views: 28,
       read_more_url: '#',
       content: 'Article covering the inauguration of the new tram line...'
     },
@@ -41,6 +47,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=13',
       category: 'Entertainment',
       published_at: '2024-05-15',
+      created_at: '2024-05-15',
+      views: 19,
       read_more_url: '#',
       content: 'Details on the upcoming concert series in Stephansplatz...'
     },
@@ -51,6 +59,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=14',
       category: 'Animals',
       published_at: '2024-05-17',
+      created_at: '2024-05-17',
+      views: 52,
       read_more_url: '#',
       content: 'More information about the new addition to the Vienna Zoo...'
     },
@@ -61,6 +71,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=15',
       category: 'Infrastructure',
       published_at: '2024-05-20',
+      created_at: '2024-05-20',
+      views: 15,
       read_more_url: '#',
       content: 'Everything about the expansion of cycling infrastructure...'
     },
@@ -71,6 +83,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=16',
       category: 'Lifestyle',
       published_at: '2024-05-22',
+      created_at: '2024-05-22',
+      views: 23,
       read_more_url: '#',
       content: 'Article on the growing trend of organic produce in Vienna...'
     },
@@ -81,6 +95,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=17',
       category: 'Business',
       published_at: '2024-05-25',
+      created_at: '2024-05-25',
+      views: 41,
       read_more_url: '#',
       content: 'Coverage of the opening ceremony of the tech hub...'
     },
@@ -91,6 +107,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=18',
       category: 'Culture',
       published_at: '2024-05-27',
+      created_at: '2024-05-27',
+      views: 17,
       read_more_url: '#',
       content: 'Insights into the renovation and history of the coffee house...'
     },
@@ -101,6 +119,8 @@ export class LocalNewsService {
       image_url: 'https://picsum.photos/400/300?random=19',
       category: 'Weather',
       published_at: '2024-05-30',
+      created_at: '2024-05-30',
+      views: 62,
       read_more_url: '#',
       content: 'Full forecast details and tips for staying dry...'
     }

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -5,6 +5,8 @@ export interface News {
   content: string;
   image: string;
   bigImage?: string;
+  created_at: string;
+  views: number;
 }
 
 export class NewsService {
@@ -15,7 +17,9 @@ export class NewsService {
       preview: 'Meteorologists predict sunny skies',
       content: 'Detailed weather forecast goes here...',
       image: 'https://picsum.photos/400/300?random=1',
-      bigImage: 'https://picsum.photos/800/600?random=1'
+      bigImage: 'https://picsum.photos/800/600?random=1',
+      created_at: '2024-05-01',
+      views: 120
     },
     {
       id: 2,
@@ -23,7 +27,9 @@ export class NewsService {
       preview: 'Automaker unveils latest EV',
       content: 'Full article about the new electric car...',
       image: 'https://picsum.photos/400/300?random=2',
-      bigImage: 'https://picsum.photos/800/600?random=2'
+      bigImage: 'https://picsum.photos/800/600?random=2',
+      created_at: '2024-05-02',
+      views: 95
     },
     {
       id: 3,
@@ -31,7 +37,9 @@ export class NewsService {
       preview: 'Local park to get major facelift',
       content: 'Details about the renovation project...',
       image: 'https://picsum.photos/400/300?random=3',
-      bigImage: 'https://picsum.photos/800/600?random=3'
+      bigImage: 'https://picsum.photos/800/600?random=3',
+      created_at: '2024-05-03',
+      views: 76
     }
   ];
 


### PR DESCRIPTION
## Summary
- enhance `News` and `LocalNewsArticle` models with `created_at` and `views`
- populate dummy creation dates and view counts in services
- show new metadata in `news-card` and `top-stories` components
- display date and view count on detail pages
- add minimal styling for new meta sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68720cfc0e0883299c641a79d2bf4389