### PR TITLE
Improve search result handling

### DIFF
--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -53,7 +53,12 @@ export class HeaderComponent {
       document.querySelectorAll('h1, h2, h3.title')
     ).find(e => e.textContent?.trim() === title) as HTMLElement | undefined;
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      const clickable = el.closest('.news-card, .story') as HTMLElement | null;
+      if (clickable) {
+        clickable.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      } else {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     }
     this.toggleSearch();
   }


### PR DESCRIPTION
## Summary
- enable search results to open article pages automatically

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68721923de408329a83422e7a5e81244