### PR TITLE
Fix weather temperature display

### DIFF
--- a/src/app/components/weather/weather.component.html
+++ b/src/app/components/weather/weather.component.html
@@ -4,7 +4,9 @@
     <div class="day" *ngFor="let d of forecast">
       <div class="date">{{ d.date | date:'EEE, MMM d' }}</div>
       <img [src]="iconUrl(d.day.condition.icon)" alt="" />
-      <div class="temp">{{ d.day.avgtemp_c | number:'1.0-0' }}°C</div>
+      <div class="temp">
+        {{ d.day?.avgtemp_c !== undefined ? (d.day.avgtemp_c | number:'1.0-0') : '?' }}°C
+      </div>
       <div class="desc">{{ d.day.condition.text }}</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show placeholder if the API doesn't return a temperature

## Testing
- `npm test --silent` *(fails: Cannot find module 'karma')*

------
https://chatgpt.com/codex/tasks/task_e_68723180b0488329afd69dd5cb3d6f56