### PR TITLE
Use long and short titles/descriptions

### DIFF
--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -1,6 +1,6 @@
 <div class="local-news-detail" *ngIf="article">
-  <h2>{{article.title}}</h2>
-  <img [src]="article.image_url" alt="{{article.title}}">
+  <h2>{{article.title_long}}</h2>
+  <img [src]="article.image_url" alt="{{article.title_long}}">
+  <p class="summary">{{article.desc_long}}</p>
   <p class="meta">Added: {{article.created_at}} | Views: {{article.views}}</p>
-  <p>{{article.content}}</p>
 </div>

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -1,10 +1,10 @@
 <div class="news-card" (click)="open()">
   <div class="image-wrapper">
-    <img [src]="article.image_url || article.image" alt="{{article.title}}" />
+    <img [src]="article.image_url || article.image" alt="{{article.title_short}}" />
   </div>
   <div class="card-body">
-    <h3 class="title">{{article.title}}</h3>
-    <p class="summary">{{article.summary || article.preview}}</p>
+    <h3 class="title">{{article.title_short}}</h3>
+    <p class="summary">{{article.desc_short}}</p>
     <small class="meta" *ngIf="article.category">
       {{article.category}} | {{article.published_at}}
     </small>

--- a/src/app/components/news-detail/news-detail.component.html
+++ b/src/app/components/news-detail/news-detail.component.html
@@ -1,6 +1,6 @@
 <div class="news-detail" *ngIf="news">
-  <h2>{{news.title}}</h2>
-  <img [src]="news.bigImage || news.image" alt="{{news.title}}">
+  <h2>{{news.title_long}}</h2>
+  <img [src]="news.bigImage || news.image" alt="{{news.title_long}}">
+  <p class="summary">{{news.desc_long}}</p>
   <p class="meta">Added: {{news.created_at}} | Views: {{news.views}}</p>
-  <p>{{news.content}}</p>
 </div>

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -1,7 +1,7 @@
 <div class="top-stories">
   <div class="story" *ngFor="let s of stories" (click)="open(s)">
-    <img [src]="s.image_url || s.image" alt="{{s.title}}" />
-    <h2>{{s.title}}</h2>
+    <img [src]="s.image_url || s.image" alt="{{s.title_short}}" />
+    <h2>{{s.title_short}}</h2>
     <small class="story-meta">Added: {{s.created_at}} | Views: {{s.views}}</small>
   </div>
 </div>

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -2,15 +2,16 @@ import { Injectable } from '@angular/core';
 
 export interface LocalNewsArticle {
   id: number;
-  title: string;
-  summary: string;
+  title_short: string;
+  desc_short: string;
+  title_long: string;
+  desc_long: string;
   image_url: string;
   category: string;
   published_at: string;
   created_at: string;
   views: number;
   read_more_url: string;
-  content: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -18,111 +19,120 @@ export class LocalNewsService {
   private viennaNews: LocalNewsArticle[] = [
     {
       id: 1,
-      title: 'Vienna Street Festival Draws Thousands',
-      summary: 'Residents flock to the annual street festival in the heart of Vienna.',
+      title_short: 'Vienna Street Festival',
+      desc_short: 'Residents flock to the annual street festival in the heart of Vienna.',
+      title_long: 'Vienna Street Festival Draws Thousands of Visitors',
+      desc_long: 'Full article about the vibrant street festival taking place in Vienna...',
       image_url: 'https://picsum.photos/400/300?random=11',
       category: 'Culture',
       published_at: '2024-05-10',
       created_at: '2024-05-10',
       views: 34,
-      read_more_url: '#',
-      content: 'Full article about the vibrant street festival taking place in Vienna...'
+      read_more_url: '#'
     },
     {
       id: 2,
-      title: 'New Tram Line Opens in the 7th District',
-      summary: 'The city introduces a new tram line improving connectivity.',
+      title_short: 'New Tram Line in 7th',
+      desc_short: 'The city introduces a new tram line improving connectivity.',
+      title_long: 'New Tram Line Opens in the 7th District',
+      desc_long: 'Article covering the inauguration of the new tram line...',
       image_url: 'https://picsum.photos/400/300?random=12',
       category: 'Local',
       published_at: '2024-05-12',
       created_at: '2024-05-12',
       views: 28,
-      read_more_url: '#',
-      content: 'Article covering the inauguration of the new tram line...'
+      read_more_url: '#'
     },
     {
       id: 3,
-      title: 'Concert Series Returns to Stephansplatz',
-      summary: 'Open-air concerts will resume this summer with local bands.',
+      title_short: 'Concerts Return to Stephansplatz',
+      desc_short: 'Open-air concerts will resume this summer with local bands.',
+      title_long: 'Concert Series Returns to Stephansplatz',
+      desc_long: 'Details on the upcoming concert series in Stephansplatz...',
       image_url: 'https://picsum.photos/400/300?random=13',
       category: 'Entertainment',
       published_at: '2024-05-15',
       created_at: '2024-05-15',
       views: 19,
-      read_more_url: '#',
-      content: 'Details on the upcoming concert series in Stephansplatz...'
+      read_more_url: '#'
     },
     {
       id: 4,
-      title: 'Vienna Zoo Welcomes Baby Panda',
-      summary: 'Exciting news as the zoo announces the birth of a panda cub.',
+      title_short: 'Vienna Zoo Welcomes Panda',
+      desc_short: 'Exciting news as the zoo announces the birth of a panda cub.',
+      title_long: 'Vienna Zoo Welcomes Baby Panda',
+      desc_long: 'More information about the new addition to the Vienna Zoo...',
       image_url: 'https://picsum.photos/400/300?random=14',
       category: 'Animals',
       published_at: '2024-05-17',
       created_at: '2024-05-17',
       views: 52,
-      read_more_url: '#',
-      content: 'More information about the new addition to the Vienna Zoo...'
+      read_more_url: '#'
     },
     {
       id: 5,
-      title: 'City Council Approves New Cycling Lanes',
-      summary: 'More cycling lanes aim to make Vienna a bike-friendly city.',
+      title_short: 'Council Approves Cycling Lanes',
+      desc_short: 'More cycling lanes aim to make Vienna a bike-friendly city.',
+      title_long: 'City Council Approves New Cycling Lanes',
+      desc_long: 'Everything about the expansion of cycling infrastructure...',
       image_url: 'https://picsum.photos/400/300?random=15',
       category: 'Infrastructure',
       published_at: '2024-05-20',
       created_at: '2024-05-20',
       views: 15,
-      read_more_url: '#',
-      content: 'Everything about the expansion of cycling infrastructure...'
+      read_more_url: '#'
     },
     {
       id: 6,
-      title: 'Local Market Showcases Organic Produce',
-      summary: 'Farmers market highlights locally sourced organic goods.',
+      title_short: 'Market Showcases Organic Produce',
+      desc_short: 'Farmers market highlights locally sourced organic goods.',
+      title_long: 'Local Market Showcases Organic Produce',
+      desc_long: 'Article on the growing trend of organic produce in Vienna...',
       image_url: 'https://picsum.photos/400/300?random=16',
       category: 'Lifestyle',
       published_at: '2024-05-22',
       created_at: '2024-05-22',
       views: 23,
-      read_more_url: '#',
-      content: 'Article on the growing trend of organic produce in Vienna...'
+      read_more_url: '#'
     },
     {
       id: 7,
-      title: 'Technology Hub Opens Near Donau City',
-      summary: 'A new technology hub promises innovation and jobs.',
+      title_short: 'Technology Hub Opens',
+      desc_short: 'A new technology hub promises innovation and jobs.',
+      title_long: 'Technology Hub Opens Near Donau City',
+      desc_long: 'Coverage of the opening ceremony of the tech hub...',
       image_url: 'https://picsum.photos/400/300?random=17',
       category: 'Business',
       published_at: '2024-05-25',
       created_at: '2024-05-25',
       views: 41,
-      read_more_url: '#',
-      content: 'Coverage of the opening ceremony of the tech hub...'
+      read_more_url: '#'
     },
     {
       id: 8,
-      title: 'Historic Coffee House Gets Renovated',
-      summary: 'Beloved coffee house reopens its doors after extensive renovation.',
+      title_short: 'Historic Coffee House Renovated',
+      desc_short: 'Beloved coffee house reopens its doors after extensive renovation.',
+      title_long: 'Historic Coffee House Gets Renovated',
+      desc_long: 'Insights into the renovation and history of the coffee house...',
       image_url: 'https://picsum.photos/400/300?random=18',
       category: 'Culture',
       published_at: '2024-05-27',
       created_at: '2024-05-27',
       views: 17,
-      read_more_url: '#',
-      content: 'Insights into the renovation and history of the coffee house...'
+      read_more_url: '#'
     },
     {
       id: 9,
-      title: 'Rainy Week Ahead, Says Forecast',
-      summary: 'Meteorologists predict a wet week for Vienna residents.',
+      title_short: 'Rainy Week Ahead',
+      desc_short: 'Meteorologists predict a wet week for Vienna residents.',
+      title_long: 'Rainy Week Ahead, Says Forecast',
+      desc_long: 'Full forecast details and tips for staying dry...',
       image_url: 'https://picsum.photos/400/300?random=19',
       category: 'Weather',
       published_at: '2024-05-30',
       created_at: '2024-05-30',
       views: 62,
-      read_more_url: '#',
-      content: 'Full forecast details and tips for staying dry...'
+      read_more_url: '#'
     }
   ];
 

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -1,8 +1,9 @@
 export interface News {
   id: number;
-  title: string;
-  preview: string;
-  content: string;
+  title_short: string;
+  desc_short: string;
+  title_long: string;
+  desc_long: string;
   image: string;
   bigImage?: string;
   created_at: string;
@@ -13,9 +14,10 @@ export class NewsService {
   private newsList: News[] = [
     {
       id: 1,
-      title: 'Sunny Weather Expected Tomorrow',
-      preview: 'Meteorologists predict sunny skies',
-      content: 'Detailed weather forecast goes here...',
+      title_short: 'Sunny Weather Expected',
+      desc_short: 'Meteorologists predict sunny skies',
+      title_long: 'Sunny Weather Expected Tomorrow - Full Forecast',
+      desc_long: 'Detailed weather forecast goes here...',
       image: 'https://picsum.photos/400/300?random=1',
       bigImage: 'https://picsum.photos/800/600?random=1',
       created_at: '2024-05-01',
@@ -23,9 +25,10 @@ export class NewsService {
     },
     {
       id: 2,
-      title: 'New Electric Car Model Released',
-      preview: 'Automaker unveils latest EV',
-      content: 'Full article about the new electric car...',
+      title_short: 'New Electric Car Released',
+      desc_short: 'Automaker unveils latest EV',
+      title_long: 'New Electric Car Model Released - In Depth',
+      desc_long: 'Full article about the new electric car...',
       image: 'https://picsum.photos/400/300?random=2',
       bigImage: 'https://picsum.photos/800/600?random=2',
       created_at: '2024-05-02',
@@ -33,9 +36,10 @@ export class NewsService {
     },
     {
       id: 3,
-      title: 'City Council Approves Park Renovation',
-      preview: 'Local park to get major facelift',
-      content: 'Details about the renovation project...',
+      title_short: 'Park Renovation Approved',
+      desc_short: 'Local park to get major facelift',
+      title_long: 'City Council Approves Park Renovation Project',
+      desc_long: 'Details about the renovation project...',
       image: 'https://picsum.photos/400/300?random=3',
       bigImage: 'https://picsum.photos/800/600?random=3',
       created_at: '2024-05-03',

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,8 @@
   },
   "files": [
     "src/main.ts",
-    "src/polyfills.ts"
+    "src/polyfills.ts",
+    "src/test.ts"
   ],
   "include": [
     "src/**/*.d.ts"


### PR DESCRIPTION
## Summary
- add short/long fields to News and LocalNewsArticle services
- display short title and description on cards and listings
- show long title and description on detail pages
- include test.ts in `tsconfig.app.json`

## Testing
- `npm run build`
- `npm test -- --watch=false` *(fails: cannot start ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_687239af697c8329a13c5340289b7453