### PR TITLE
Load local news from Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NewsApp
 
-This is a simple Angular application that displays news articles from a dummy service.
+This is a simple Angular application that displays news articles fetched from a Firebase Firestore collection.
 
 ## Development
 
@@ -17,4 +17,4 @@ This is a simple Angular application that displays news articles from a dummy se
    npm test
    ```
 
-The application is structured with reusable components and a `NewsService` that returns mock data. It is ready for future extension to load data from an external API.
+The application is structured with reusable components. Both the `NewsService` and `LocalNewsService` load articles from the same `news` collection in Firestore. A demo Firebase configuration is already provided in the environment files, but you can replace it with your own project settings if desired.

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "@angular/common": "~17.0.0",
     "@angular/compiler": "~17.0.0",
     "@angular/core": "~17.0.0",
+    "@angular/fire": "^17.0.0",
     "@angular/forms": "~17.0.0",
     "@angular/platform-browser": "~17.0.0",
     "@angular/platform-browser-dynamic": "~17.0.0",
     "@angular/router": "~17.0.0",
+    "firebase": "^11.0.0",
     "rxjs": "^7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "^0.14.10"
@@ -24,6 +26,12 @@
     "@angular-devkit/build-angular": "~17.0.0",
     "@angular/cli": "~17.0.0",
     "@angular/compiler-cli": "~17.0.0",
+    "jasmine-core": "^5.8.0",
+    "karma": "^6.4.4",
+    "karma-chrome-launcher": "^3.2.0",
+    "karma-coverage": "^2.2.1",
+    "karma-jasmine": "^5.1.0",
+    "karma-jasmine-html-reporter": "^2.1.0",
     "typescript": "~5.2.0"
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,9 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
+import { AngularFireModule } from '@angular/fire/compat';
+import { AngularFirestoreModule } from '@angular/fire/compat/firestore';
+import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './components/header/header.component';
 import { FooterComponent } from './components/footer/footer.component';
@@ -28,6 +31,8 @@ import { WeatherComponent } from './components/weather/weather.component';
   imports: [
     BrowserModule,
     HttpClientModule,
+    AngularFireModule.initializeApp(environment.firebase),
+    AngularFirestoreModule,
     RouterModule.forRoot([
       { path: '', redirectTo: 'local-news/vienna', pathMatch: 'full' },
       { path: 'news/:id', component: NewsDetailComponent },

--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -1,6 +1,6 @@
-<div class="local-news-detail" *ngIf="article">
+<div class="local-news-detail" *ngIf="article$ | async as article">
   <h2>{{article.title_long}}</h2>
-  <img [src]="article.image_url" alt="{{article.title_long}}">
+  <img [src]="article.image_url || article.image" alt="{{article.title_long}}">
   <p class="summary">{{article.desc_long}}</p>
   <p class="meta">Added: {{article.created_at}} | Views: {{article.views}}</p>
 </div>

--- a/src/app/components/local-news-detail/local-news-detail.component.ts
+++ b/src/app/components/local-news-detail/local-news-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LocalNewsArticle, LocalNewsService } from '../../services/local-news.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-local-news-detail',
@@ -8,15 +9,16 @@ import { LocalNewsArticle, LocalNewsService } from '../../services/local-news.se
   styleUrls: ['./local-news-detail.component.scss']
 })
 export class LocalNewsDetailComponent implements OnInit {
-  article?: LocalNewsArticle;
+  article$?: Observable<LocalNewsArticle>;
 
   constructor(private route: ActivatedRoute, private router: Router, private service: LocalNewsService) {}
 
   ngOnInit(): void {
-    const id = Number(this.route.snapshot.paramMap.get('id'));
-    this.service.incrementViews(id);
-    this.article = this.service.getViennaNewsById(id);
-    if (!this.article) {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.service.incrementViews(id);
+      this.article$ = this.service.getViennaNewsById(id);
+    } else {
       this.router.navigate(['/local-news/vienna']);
     }
   }

--- a/src/app/components/news-detail/news-detail.component.html
+++ b/src/app/components/news-detail/news-detail.component.html
@@ -1,4 +1,4 @@
-<div class="news-detail" *ngIf="news">
+<div class="news-detail" *ngIf="news$ | async as news">
   <h2>{{news.title_long}}</h2>
   <img [src]="news.bigImage || news.image" alt="{{news.title_long}}">
   <p class="summary">{{news.desc_long}}</p>

--- a/src/app/components/news-detail/news-detail.component.ts
+++ b/src/app/components/news-detail/news-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NewsService, News } from '../../services/news.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-news-detail',
@@ -8,7 +9,7 @@ import { NewsService, News } from '../../services/news.service';
   styleUrls: ['./news-detail.component.scss']
 })
 export class NewsDetailComponent implements OnInit {
-  news?: News;
+  news$?: Observable<News>;
 
   constructor(
     private route: ActivatedRoute,
@@ -17,9 +18,10 @@ export class NewsDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const id = Number(this.route.snapshot.paramMap.get('id'));
-    this.news = this.newsService.getNewsById(id);
-    if (!this.news) {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.news$ = this.newsService.getNewsById(id);
+    } else {
       this.router.navigate(['/']);
     }
   }

--- a/src/app/components/vienna-news/vienna-news.component.ts
+++ b/src/app/components/vienna-news/vienna-news.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { LocalNewsArticle, LocalNewsService } from '../../services/local-news.service';
+import { first } from 'rxjs';
 
 @Component({
   selector: 'app-vienna-news',
@@ -13,8 +14,12 @@ export class ViennaNewsComponent implements OnInit {
   constructor(private localNews: LocalNewsService) {}
 
   ngOnInit(): void {
-    const all = this.localNews.getViennaNews();
-    this.topStories = all.slice(0, 3);
-    this.feed = all.slice(3);
+    this.localNews
+      .getViennaNews()
+      .pipe(first())
+      .subscribe(all => {
+        this.topStories = all.slice(0, 3);
+        this.feed = all.slice(3);
+      });
   }
 }

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -1,153 +1,38 @@
 import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import firebase from 'firebase/compat/app';
+import { Observable } from 'rxjs';
+import { News } from './news.service';
 
-export interface LocalNewsArticle {
-  id: number;
-  title_short: string;
-  desc_short: string;
-  title_long: string;
-  desc_long: string;
-  image_url: string;
-  category: string;
-  published_at: string;
-  created_at: string;
-  views: number;
-  read_more_url: string;
+export interface LocalNewsArticle extends News {
+  image_url?: string;
+  category?: string;
+  published_at?: string;
+  read_more_url?: string;
 }
 
 @Injectable({ providedIn: 'root' })
 export class LocalNewsService {
-  private viennaNews: LocalNewsArticle[] = [
-    {
-      id: 1,
-      title_short: 'Vienna Street Festival',
-      desc_short: 'Residents flock to the annual street festival in the heart of Vienna.',
-      title_long: 'Vienna Street Festival Draws Thousands of Visitors',
-      desc_long: 'Full article about the vibrant street festival taking place in Vienna...',
-      image_url: 'https://picsum.photos/400/300?random=11',
-      category: 'Culture',
-      published_at: '2024-05-10',
-      created_at: '2024-05-10',
-      views: 34,
-      read_more_url: '#'
-    },
-    {
-      id: 2,
-      title_short: 'New Tram Line in 7th',
-      desc_short: 'The city introduces a new tram line improving connectivity.',
-      title_long: 'New Tram Line Opens in the 7th District',
-      desc_long: 'Article covering the inauguration of the new tram line...',
-      image_url: 'https://picsum.photos/400/300?random=12',
-      category: 'Local',
-      published_at: '2024-05-12',
-      created_at: '2024-05-12',
-      views: 28,
-      read_more_url: '#'
-    },
-    {
-      id: 3,
-      title_short: 'Concerts Return to Stephansplatz',
-      desc_short: 'Open-air concerts will resume this summer with local bands.',
-      title_long: 'Concert Series Returns to Stephansplatz',
-      desc_long: 'Details on the upcoming concert series in Stephansplatz...',
-      image_url: 'https://picsum.photos/400/300?random=13',
-      category: 'Entertainment',
-      published_at: '2024-05-15',
-      created_at: '2024-05-15',
-      views: 19,
-      read_more_url: '#'
-    },
-    {
-      id: 4,
-      title_short: 'Vienna Zoo Welcomes Panda',
-      desc_short: 'Exciting news as the zoo announces the birth of a panda cub.',
-      title_long: 'Vienna Zoo Welcomes Baby Panda',
-      desc_long: 'More information about the new addition to the Vienna Zoo...',
-      image_url: 'https://picsum.photos/400/300?random=14',
-      category: 'Animals',
-      published_at: '2024-05-17',
-      created_at: '2024-05-17',
-      views: 52,
-      read_more_url: '#'
-    },
-    {
-      id: 5,
-      title_short: 'Council Approves Cycling Lanes',
-      desc_short: 'More cycling lanes aim to make Vienna a bike-friendly city.',
-      title_long: 'City Council Approves New Cycling Lanes',
-      desc_long: 'Everything about the expansion of cycling infrastructure...',
-      image_url: 'https://picsum.photos/400/300?random=15',
-      category: 'Infrastructure',
-      published_at: '2024-05-20',
-      created_at: '2024-05-20',
-      views: 15,
-      read_more_url: '#'
-    },
-    {
-      id: 6,
-      title_short: 'Market Showcases Organic Produce',
-      desc_short: 'Farmers market highlights locally sourced organic goods.',
-      title_long: 'Local Market Showcases Organic Produce',
-      desc_long: 'Article on the growing trend of organic produce in Vienna...',
-      image_url: 'https://picsum.photos/400/300?random=16',
-      category: 'Lifestyle',
-      published_at: '2024-05-22',
-      created_at: '2024-05-22',
-      views: 23,
-      read_more_url: '#'
-    },
-    {
-      id: 7,
-      title_short: 'Technology Hub Opens',
-      desc_short: 'A new technology hub promises innovation and jobs.',
-      title_long: 'Technology Hub Opens Near Donau City',
-      desc_long: 'Coverage of the opening ceremony of the tech hub...',
-      image_url: 'https://picsum.photos/400/300?random=17',
-      category: 'Business',
-      published_at: '2024-05-25',
-      created_at: '2024-05-25',
-      views: 41,
-      read_more_url: '#'
-    },
-    {
-      id: 8,
-      title_short: 'Historic Coffee House Renovated',
-      desc_short: 'Beloved coffee house reopens its doors after extensive renovation.',
-      title_long: 'Historic Coffee House Gets Renovated',
-      desc_long: 'Insights into the renovation and history of the coffee house...',
-      image_url: 'https://picsum.photos/400/300?random=18',
-      category: 'Culture',
-      published_at: '2024-05-27',
-      created_at: '2024-05-27',
-      views: 17,
-      read_more_url: '#'
-    },
-    {
-      id: 9,
-      title_short: 'Rainy Week Ahead',
-      desc_short: 'Meteorologists predict a wet week for Vienna residents.',
-      title_long: 'Rainy Week Ahead, Says Forecast',
-      desc_long: 'Full forecast details and tips for staying dry...',
-      image_url: 'https://picsum.photos/400/300?random=19',
-      category: 'Weather',
-      published_at: '2024-05-30',
-      created_at: '2024-05-30',
-      views: 62,
-      read_more_url: '#'
-    }
-  ];
+  constructor(private firestore: AngularFirestore) {}
 
-  getViennaNews(): LocalNewsArticle[] {
-    return this.viennaNews;
+  getViennaNews(): Observable<LocalNewsArticle[]> {
+    return this.firestore
+      .collection<LocalNewsArticle>('news')
+      .valueChanges({ idField: 'id' });
   }
 
-  getViennaNewsById(id: number): LocalNewsArticle | undefined {
-    return this.viennaNews.find(n => n.id === id);
+  getViennaNewsById(id: string): Observable<LocalNewsArticle> {
+    return this.firestore
+      .collection<LocalNewsArticle>('news')
+      .doc(id)
+      .valueChanges({ idField: 'id' }) as Observable<LocalNewsArticle>;
   }
 
-  incrementViews(id: number): void {
-    const article = this.getViennaNewsById(id);
-    if (article) {
-      article.views += 1;
-    }
+  incrementViews(id: string): Promise<void> {
+    // Increment the views field atomically in Firestore
+    return this.firestore
+      .collection('news')
+      .doc(id)
+      .update({ views: firebase.firestore.FieldValue.increment(1) });
   }
 }

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -1,5 +1,9 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable } from 'rxjs';
+
 export interface News {
-  id: number;
+  id: string;
   title_short: string;
   desc_short: string;
   title_long: string;
@@ -10,48 +14,20 @@ export interface News {
   views: number;
 }
 
+@Injectable({ providedIn: 'root' })
 export class NewsService {
-  private newsList: News[] = [
-    {
-      id: 1,
-      title_short: 'Sunny Weather Expected',
-      desc_short: 'Meteorologists predict sunny skies',
-      title_long: 'Sunny Weather Expected Tomorrow - Full Forecast',
-      desc_long: 'Detailed weather forecast goes here...',
-      image: 'https://picsum.photos/400/300?random=1',
-      bigImage: 'https://picsum.photos/800/600?random=1',
-      created_at: '2024-05-01',
-      views: 120
-    },
-    {
-      id: 2,
-      title_short: 'New Electric Car Released',
-      desc_short: 'Automaker unveils latest EV',
-      title_long: 'New Electric Car Model Released - In Depth',
-      desc_long: 'Full article about the new electric car...',
-      image: 'https://picsum.photos/400/300?random=2',
-      bigImage: 'https://picsum.photos/800/600?random=2',
-      created_at: '2024-05-02',
-      views: 95
-    },
-    {
-      id: 3,
-      title_short: 'Park Renovation Approved',
-      desc_short: 'Local park to get major facelift',
-      title_long: 'City Council Approves Park Renovation Project',
-      desc_long: 'Details about the renovation project...',
-      image: 'https://picsum.photos/400/300?random=3',
-      bigImage: 'https://picsum.photos/800/600?random=3',
-      created_at: '2024-05-03',
-      views: 76
-    }
-  ];
+  constructor(private firestore: AngularFirestore) {}
 
-  getNews(): News[] {
-    return this.newsList;
+  getNews(): Observable<News[]> {
+    return this.firestore
+      .collection<News>('news')
+      .valueChanges({ idField: 'id' });
   }
 
-  getNewsById(id: number): News | undefined {
-    return this.newsList.find(n => n.id === id);
+  getNewsById(id: string): Observable<News> {
+    return this.firestore
+      .collection<News>('news')
+      .doc(id)
+      .valueChanges({ idField: 'id' }) as Observable<News>;
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,15 @@
 export const environment = {
   production: true,
+  firebase: {
+    apiKey: 'AIzaSyBHwg4z60Xl_yZepJRAUi2_xN57Ex65nkI',
+    authDomain: 'fir-storage-demo-f723f.firebaseapp.com',
+    databaseURL: 'https://fir-storage-demo-f723f.firebaseio.com',
+    projectId: 'fir-storage-demo-f723f',
+    storageBucket: 'fir-storage-demo-f723f.appspot.com',
+    messagingSenderId: '1065468229127',
+    appId: '1:1065468229127:web:192e94998f9411933ddca2',
+    measurementId: 'G-NT1EKHRCPW'
+  },
   weatherApi: {
     apiKey: "f49da499dde04a5fa9820136251506"
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,15 @@
 export const environment = {
   production: false,
+  firebase: {
+    apiKey: 'AIzaSyBHwg4z60Xl_yZepJRAUi2_xN57Ex65nkI',
+    authDomain: 'fir-storage-demo-f723f.firebaseapp.com',
+    databaseURL: 'https://fir-storage-demo-f723f.firebaseio.com',
+    projectId: 'fir-storage-demo-f723f',
+    storageBucket: 'fir-storage-demo-f723f.appspot.com',
+    messagingSenderId: '1065468229127',
+    appId: '1:1065468229127:web:192e94998f9411933ddca2',
+    measurementId: 'G-NT1EKHRCPW'
+  },
   weatherApi: {
     apiKey: 'f49da499dde04a5fa9820136251506'
   }


### PR DESCRIPTION
## Summary
- pull local news from the same Firestore `news` collection
- update LocalNewsDetailComponent to work with async data
- load Vienna news asynchronously
- clarify README about Firestore usage

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module 'karma')*


------
https://chatgpt.com/codex/tasks/task_e_68724228263883299b83688e0d14f8cb