### PR TITLE
Ensure Local News follows News structure

### DIFF
--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -1,6 +1,6 @@
 <div class="local-news-detail" *ngIf="article$ | async as article">
   <h2>{{article.title_long}}</h2>
-  <img [src]="article.image_url || article.image" alt="{{article.title_long}}">
+  <img [src]="article.image" alt="{{article.title_long}}">
   <p class="summary">{{article.desc_long}}</p>
   <p class="meta">Added: {{article.created_at}} | Views: {{article.views}}</p>
 </div>

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -1,13 +1,10 @@
 <div class="news-card" (click)="open()">
   <div class="image-wrapper">
-    <img [src]="article.image_url || article.image" alt="{{article.title_short}}" />
+    <img [src]="article.image" alt="{{article.title_short}}" />
   </div>
   <div class="card-body">
     <h3 class="title">{{article.title_short}}</h3>
     <p class="summary">{{article.desc_short}}</p>
-    <small class="meta" *ngIf="article.category">
-      {{article.category}} | {{article.published_at}}
-    </small>
     <small class="meta" *ngIf="article.created_at || article.views !== undefined">
       Added: {{article.created_at}} | Views: {{article.views}}
     </small>

--- a/src/app/components/news-card/news-card.component.ts
+++ b/src/app/components/news-card/news-card.component.ts
@@ -8,7 +8,7 @@ import { LocalNewsArticle } from '../../services/local-news.service';
   styleUrls: ['./news-card.component.scss']
 })
 export class NewsCardComponent {
-  @Input() article: any;
+  @Input() article!: LocalNewsArticle;
   @Input() baseRoute = '/local-news/vienna';
 
   constructor(private router: Router) {}

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -1,6 +1,6 @@
 <div class="top-stories">
   <div class="story" *ngFor="let s of stories" (click)="open(s)">
-    <img [src]="s.image_url || s.image" alt="{{s.title_short}}" />
+    <img [src]="s.image" alt="{{s.title_short}}" />
     <h2>{{s.title_short}}</h2>
     <small class="story-meta">Added: {{s.created_at}} | Views: {{s.views}}</small>
   </div>

--- a/src/app/components/top-stories/top-stories.component.ts
+++ b/src/app/components/top-stories/top-stories.component.ts
@@ -8,12 +8,12 @@ import { LocalNewsArticle } from '../../services/local-news.service';
   styleUrls: ['./top-stories.component.scss']
 })
 export class TopStoriesComponent {
-  @Input() stories: any[] = [];
+  @Input() stories: LocalNewsArticle[] = [];
   @Input() baseRoute = '/local-news/vienna';
 
   constructor(private router: Router) {}
 
-  open(article: any) {
+  open(article: LocalNewsArticle) {
     this.router.navigate([this.baseRoute, article.id]);
   }
 }

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -4,12 +4,9 @@ import firebase from 'firebase/compat/app';
 import { Observable } from 'rxjs';
 import { News } from './news.service';
 
-export interface LocalNewsArticle extends News {
-  image_url?: string;
-  category?: string;
-  published_at?: string;
-  read_more_url?: string;
-}
+// Local news articles follow the same structure as regular news
+// defined in the `News` interface. No additional fields are required.
+export type LocalNewsArticle = News;
 
 @Injectable({ providedIn: 'root' })
 export class LocalNewsService {


### PR DESCRIPTION
## Summary
- unify LocalNewsArticle with the `News` interface
- update local news components to use the `image` field
- remove unused optional fields in components
- use `LocalNewsArticle` type in TopStories and NewsCard components

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_6872a884f88083299473c6cf716d7fa2