### PR TITLE
Improve loading UX and article caching

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { TopStoriesComponent } from './components/top-stories/top-stories.compon
 import { ViennaNewsComponent } from './components/vienna-news/vienna-news.component';
 import { LocalNewsDetailComponent } from './components/local-news-detail/local-news-detail.component';
 import { WeatherComponent } from './components/weather/weather.component';
+import { MailmanLoaderComponent } from './components/mailman-loader/mailman-loader.component';
 
 @NgModule({
   declarations: [
@@ -26,7 +27,8 @@ import { WeatherComponent } from './components/weather/weather.component';
     TopStoriesComponent,
     ViennaNewsComponent,
     LocalNewsDetailComponent,
-    WeatherComponent
+    WeatherComponent,
+    MailmanLoaderComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -1,6 +1,7 @@
+<app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
 <div class="local-news-detail" *ngIf="article$ | async as article">
   <h2>{{article.title_long}}</h2>
   <img [src]="article.image" alt="{{article.title_long}}">
   <p class="summary">{{article.desc_long}}</p>
-  <p class="meta">Added: {{article.created_at}} | Views: {{article.views}}</p>
+  <p class="meta">Added: {{article.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{article.views}}</p>
 </div>

--- a/src/app/components/local-news-detail/local-news-detail.component.ts
+++ b/src/app/components/local-news-detail/local-news-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LocalNewsArticle, LocalNewsService } from '../../services/local-news.service';
-import { Observable } from 'rxjs';
+import { Observable, of, first } from 'rxjs';
 
 @Component({
   selector: 'app-local-news-detail',
@@ -10,14 +10,27 @@ import { Observable } from 'rxjs';
 })
 export class LocalNewsDetailComponent implements OnInit {
   article$?: Observable<LocalNewsArticle>;
+  loading = false;
+  error = false;
 
   constructor(private route: ActivatedRoute, private router: Router, private service: LocalNewsService) {}
 
   ngOnInit(): void {
+    const stateArticle = this.router.getCurrentNavigation()?.extras.state?.['article'] as LocalNewsArticle | undefined;
     const id = this.route.snapshot.paramMap.get('id');
-    if (id) {
-      //this.service.incrementViews(id);
+
+    if (stateArticle) {
+      this.article$ = of(stateArticle);
+    } else if (id) {
+      this.loading = true;
       this.article$ = this.service.getViennaNewsById(id);
+      this.article$.pipe(first()).subscribe({
+        next: () => (this.loading = false),
+        error: () => {
+          this.loading = false;
+          this.error = true;
+        }
+      });
     } else {
       this.router.navigate(['/local-news/vienna']);
     }

--- a/src/app/components/mailman-loader/mailman-loader.component.html
+++ b/src/app/components/mailman-loader/mailman-loader.component.html
@@ -1,0 +1,6 @@
+<div class="mailman-wrapper" [class.error]="error">
+  <div class="mailman"></div>
+  <p class="error-message" *ngIf="error">
+    Oops! The mail couldn't be delivered. Please try again.
+  </p>
+</div>

--- a/src/app/components/mailman-loader/mailman-loader.component.html
+++ b/src/app/components/mailman-loader/mailman-loader.component.html
@@ -1,5 +1,6 @@
 <div class="mailman-wrapper" [class.error]="error">
   <div class="mailman"></div>
+  <div class="letter" *ngIf="error"></div>
   <p class="error-message" *ngIf="error">
     Oops! The mail couldn't be delivered. Please try again.
   </p>

--- a/src/app/components/mailman-loader/mailman-loader.component.scss
+++ b/src/app/components/mailman-loader/mailman-loader.component.scss
@@ -1,0 +1,30 @@
+.mailman-wrapper {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  margin: 40px auto;
+}
+
+.mailman {
+  width: 64px;
+  height: 64px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><circle cx='16' cy='12' r='8' fill='%23555'/><rect x='12' y='20' width='8' height='20' fill='%23555'/><rect x='20' y='26' width='20' height='12' rx='2' ry='2' fill='%23999'/></svg>");
+  background-size: contain;
+  background-repeat: no-repeat;
+  animation: walk 4s linear infinite;
+}
+
+.error .mailman {
+  animation: none;
+}
+
+.error-message {
+  text-align: center;
+  font-size: 0.9rem;
+  margin-top: 8px;
+}
+
+@keyframes walk {
+  0% { transform: translateX(-100px); }
+  100% { transform: translateX(100vw); }
+}

--- a/src/app/components/mailman-loader/mailman-loader.component.scss
+++ b/src/app/components/mailman-loader/mailman-loader.component.scss
@@ -1,21 +1,40 @@
+
 .mailman-wrapper {
   position: relative;
   width: 30vmin;
   height: 30vmin;
-  margin: 2vmin auto;
+  margin: 4vmin auto;
 }
 
 .mailman {
   width: 100%;
   height: 100%;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><circle cx='16' cy='12' r='8' fill='%23555'/><rect x='12' y='20' width='8' height='20' fill='%23555'/><rect x='20' y='26' width='20' height='12' rx='2' ry='2' fill='%23999'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><path d='M28 50h-4v-14h4zM40 50h-4V36h4z' fill='%23447ab4'/><rect x='26' y='22' width='12' height='16' rx='2' fill='%235975a1'/><path d='M24 28h-6v8h6z' fill='%238d6e63'/><circle cx='32' cy='14' r='6' fill='%23a67c52'/><rect x='28' y='8' width='8' height='3' fill='%23447ab4'/></svg>");
   background-size: contain;
   background-repeat: no-repeat;
-  animation: walk 8s linear infinite;
+  position: absolute;
+  bottom: 0;
+  animation: walk 6s linear infinite;
+}
+
+.letter {
+  position: absolute;
+  bottom: 40%;
+  left: 50%;
+  width: 6vmin;
+  height: 4vmin;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 16'><rect width='24' height='16' rx='2' fill='%23fff' stroke='%23999'/><path d='M0 0l12 8L24 0' fill='none' stroke='%23999'/></svg>");
+  background-size: contain;
+  background-repeat: no-repeat;
+  animation: drop 2s ease-in-out infinite;
 }
 
 .error .mailman {
   animation: none;
+}
+
+.error .letter {
+  animation: drop 2s ease-in-out infinite;
 }
 
 .error-message {
@@ -25,6 +44,11 @@
 }
 
 @keyframes walk {
-  0% { transform: translateX(-30vmin); }
-  100% { transform: translateX(calc(100vw + 30vmin)); }
+  0% { transform: translateX(-40vmin); }
+  100% { transform: translateX(calc(100vw + 40vmin)); }
+}
+
+@keyframes drop {
+  0% { transform: translate(0, 0); opacity: 1; }
+  100% { transform: translate(-10vmin, 10vmin); opacity: 0; }
 }

--- a/src/app/components/mailman-loader/mailman-loader.component.scss
+++ b/src/app/components/mailman-loader/mailman-loader.component.scss
@@ -1,17 +1,17 @@
 .mailman-wrapper {
   position: relative;
-  width: 64px;
-  height: 64px;
-  margin: 40px auto;
+  width: 30vmin;
+  height: 30vmin;
+  margin: 2vmin auto;
 }
 
 .mailman {
-  width: 64px;
-  height: 64px;
+  width: 100%;
+  height: 100%;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><circle cx='16' cy='12' r='8' fill='%23555'/><rect x='12' y='20' width='8' height='20' fill='%23555'/><rect x='20' y='26' width='20' height='12' rx='2' ry='2' fill='%23999'/></svg>");
   background-size: contain;
   background-repeat: no-repeat;
-  animation: walk 4s linear infinite;
+  animation: walk 8s linear infinite;
 }
 
 .error .mailman {
@@ -25,6 +25,6 @@
 }
 
 @keyframes walk {
-  0% { transform: translateX(-100px); }
-  100% { transform: translateX(100vw); }
+  0% { transform: translateX(-30vmin); }
+  100% { transform: translateX(calc(100vw + 30vmin)); }
 }

--- a/src/app/components/mailman-loader/mailman-loader.component.ts
+++ b/src/app/components/mailman-loader/mailman-loader.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-mailman-loader',
+  templateUrl: './mailman-loader.component.html',
+  styleUrls: ['./mailman-loader.component.scss']
+})
+export class MailmanLoaderComponent {
+  @Input() error = false;
+}

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -6,7 +6,7 @@
     <h3 class="title">{{article.title_short}}</h3>
     <p class="summary">{{article.desc_short}}</p>
     <small class="meta" *ngIf="article.created_at || article.views !== undefined">
-      Added: {{article.created_at}} | Views: {{article.views}}
+      Added: {{article.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{article.views}}
     </small>
   </div>
 </div>

--- a/src/app/components/news-card/news-card.component.ts
+++ b/src/app/components/news-card/news-card.component.ts
@@ -14,6 +14,8 @@ export class NewsCardComponent {
   constructor(private router: Router) {}
 
   open() {
-    this.router.navigate([this.baseRoute, this.article.id]);
+    this.router.navigate([this.baseRoute, this.article.id], {
+      state: { article: this.article }
+    });
   }
 }

--- a/src/app/components/news-detail/news-detail.component.html
+++ b/src/app/components/news-detail/news-detail.component.html
@@ -1,6 +1,7 @@
+<app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
 <div class="news-detail" *ngIf="news$ | async as news">
   <h2>{{news.title_long}}</h2>
   <img [src]="news.bigImage || news.image" alt="{{news.title_long}}">
   <p class="summary">{{news.desc_long}}</p>
-  <p class="meta">Added: {{news.created_at}} | Views: {{news.views}}</p>
+  <p class="meta">Added: {{news.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{news.views}}</p>
 </div>

--- a/src/app/components/news-detail/news-detail.component.ts
+++ b/src/app/components/news-detail/news-detail.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NewsService, News } from '../../services/news.service';
-import { Observable } from 'rxjs';
+import { Observable, of, first } from 'rxjs';
 
 @Component({
   selector: 'app-news-detail',
@@ -10,6 +10,8 @@ import { Observable } from 'rxjs';
 })
 export class NewsDetailComponent implements OnInit {
   news$?: Observable<News>;
+  loading = false;
+  error = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -18,9 +20,21 @@ export class NewsDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    const stateNews = this.router.getCurrentNavigation()?.extras.state?.['article'] as News | undefined;
     const id = this.route.snapshot.paramMap.get('id');
-    if (id) {
+
+    if (stateNews) {
+      this.news$ = of(stateNews);
+    } else if (id) {
+      this.loading = true;
       this.news$ = this.newsService.getNewsById(id);
+      this.news$.pipe(first()).subscribe({
+        next: () => (this.loading = false),
+        error: () => {
+          this.loading = false;
+          this.error = true;
+        }
+      });
     } else {
       this.router.navigate(['/']);
     }

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -2,6 +2,6 @@
   <div class="story" *ngFor="let s of stories" (click)="open(s)">
     <img [src]="s.image" alt="{{s.title_short}}" />
     <h2>{{s.title_short}}</h2>
-    <small class="story-meta">Added: {{s.created_at}} | Views: {{s.views}}</small>
+    <small class="story-meta">Added: {{s.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{s.views}}</small>
   </div>
 </div>

--- a/src/app/components/top-stories/top-stories.component.ts
+++ b/src/app/components/top-stories/top-stories.component.ts
@@ -14,6 +14,8 @@ export class TopStoriesComponent {
   constructor(private router: Router) {}
 
   open(article: LocalNewsArticle) {
-    this.router.navigate([this.baseRoute, article.id]);
+    this.router.navigate([this.baseRoute, article.id], {
+      state: { article }
+    });
   }
 }

--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -1,4 +1,5 @@
 <div class="page">
+  <app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
   <h1 class="page-title">Vienna Local News</h1>
   <app-top-stories [stories]="topStories"></app-top-stories>
   <div class="content-grid">

--- a/src/app/components/vienna-news/vienna-news.component.ts
+++ b/src/app/components/vienna-news/vienna-news.component.ts
@@ -10,6 +10,8 @@ import { first } from 'rxjs';
 export class ViennaNewsComponent implements OnInit {
   topStories: LocalNewsArticle[] = [];
   feed: LocalNewsArticle[] = [];
+  loading = true;
+  error = false;
 
   constructor(private localNews: LocalNewsService) {}
 
@@ -17,9 +19,16 @@ export class ViennaNewsComponent implements OnInit {
     this.localNews
       .getViennaNews()
       .pipe(first())
-      .subscribe(all => {
-        this.topStories = all.slice(0, 3);
-        this.feed = all.slice(3);
+      .subscribe({
+        next: all => {
+          this.topStories = all.slice(0, 3);
+          this.feed = all.slice(3);
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+          this.error = true;
+        }
       });
   }
 }

--- a/src/app/services/local-news.service.ts
+++ b/src/app/services/local-news.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import firebase from 'firebase/compat/app';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { News } from './news.service';
 
 // Local news articles follow the same structure as regular news
@@ -12,17 +13,30 @@ export type LocalNewsArticle = News;
 export class LocalNewsService {
   constructor(private firestore: AngularFirestore) {}
 
+  private normalizeArticle<T extends { created_at: any }>(article: T): T & { created_at: Date } {
+    const raw = article.created_at as any;
+    let date: Date;
+    if (raw && typeof raw === 'object' && 'toDate' in raw) {
+      date = (raw as firebase.firestore.Timestamp).toDate();
+    } else {
+      date = new Date(raw);
+    }
+    return { ...(article as any), created_at: date };
+  }
+
   getViennaNews(): Observable<LocalNewsArticle[]> {
     return this.firestore
       .collection<LocalNewsArticle>('news')
-      .valueChanges({ idField: 'id' });
+      .valueChanges({ idField: 'id' })
+      .pipe(map(list => list.map(a => this.normalizeArticle(a))));
   }
 
   getViennaNewsById(id: string): Observable<LocalNewsArticle> {
     return this.firestore
       .collection<LocalNewsArticle>('news')
       .doc(id)
-      .valueChanges({ idField: 'id' }) as Observable<LocalNewsArticle>;
+      .valueChanges({ idField: 'id' })
+      .pipe(map(a => (a ? this.normalizeArticle(a) : (a as any))));
   }
 
   incrementViews(id: string): Promise<void> {

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
+import firebase from 'firebase/compat/app';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 export interface News {
   id: string;
@@ -10,7 +12,7 @@ export interface News {
   desc_long: string;
   image: string;
   bigImage?: string;
-  created_at: string;
+  created_at: any;
   views: number;
 }
 
@@ -18,16 +20,29 @@ export interface News {
 export class NewsService {
   constructor(private firestore: AngularFirestore) {}
 
+  private normalizeArticle<T extends { created_at: any }>(article: T): T & { created_at: Date } {
+    const raw = article.created_at as any;
+    let date: Date;
+    if (raw && typeof raw === 'object' && 'toDate' in raw) {
+      date = (raw as firebase.firestore.Timestamp).toDate();
+    } else {
+      date = new Date(raw);
+    }
+    return { ...(article as any), created_at: date };
+  }
+
   getNews(): Observable<News[]> {
     return this.firestore
       .collection<News>('news')
-      .valueChanges({ idField: 'id' });
+      .valueChanges({ idField: 'id' })
+      .pipe(map(list => list.map(n => this.normalizeArticle(n))));
   }
 
   getNewsById(id: string): Observable<News> {
     return this.firestore
       .collection<News>('news')
       .doc(id)
-      .valueChanges({ idField: 'id' }) as Observable<News>;
+      .valueChanges({ idField: 'id' })
+      .pipe(map(n => (n ? this.normalizeArticle(n) : (n as any))));
   }
 }


### PR DESCRIPTION
## Summary
- add MailmanLoader animation component
- show mailman when Vienna news or articles load or fail
- cache article data when navigating to detail views
- format article dates using 12‑hour time with am/pm

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6873f5d696388329b1e4c52aa5276ebf