### PR TITLE
Add basic cookie consent support

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,4 @@
 <app-header></app-header>
 <router-outlet></router-outlet>
+<app-cookie-banner></app-cookie-banner>
 <app-footer></app-footer>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
 import { AngularFireModule } from '@angular/fire/compat';
 import { AngularFirestoreModule } from '@angular/fire/compat/firestore';
 import { environment } from '../environments/environment';
@@ -15,6 +16,9 @@ import { TopStoriesComponent } from './components/top-stories/top-stories.compon
 import { ViennaNewsComponent } from './components/vienna-news/vienna-news.component';
 import { LocalNewsDetailComponent } from './components/local-news-detail/local-news-detail.component';
 import { WeatherComponent } from './components/weather/weather.component';
+import { CookieBannerComponent } from './components/cookie-banner/cookie-banner.component';
+import { CookieSettingsComponent } from './components/cookie-settings/cookie-settings.component';
+import { CookiePolicyComponent } from './components/cookie-policy/cookie-policy.component';
 
 @NgModule({
   declarations: [
@@ -26,10 +30,14 @@ import { WeatherComponent } from './components/weather/weather.component';
     TopStoriesComponent,
     ViennaNewsComponent,
     LocalNewsDetailComponent,
-    WeatherComponent
+    WeatherComponent,
+    CookieBannerComponent,
+    CookieSettingsComponent,
+    CookiePolicyComponent
   ],
   imports: [
     BrowserModule,
+    FormsModule,
     HttpClientModule,
     AngularFireModule.initializeApp(environment.firebase),
     AngularFirestoreModule,
@@ -37,7 +45,9 @@ import { WeatherComponent } from './components/weather/weather.component';
       { path: '', redirectTo: 'local-news/vienna', pathMatch: 'full' },
       { path: 'news/:id', component: NewsDetailComponent },
       { path: 'local-news/vienna', component: ViennaNewsComponent },
-      { path: 'local-news/vienna/:id', component: LocalNewsDetailComponent }
+      { path: 'local-news/vienna/:id', component: LocalNewsDetailComponent },
+      { path: 'cookie-settings', component: CookieSettingsComponent },
+      { path: 'cookie-policy', component: CookiePolicyComponent }
     ])
   ],
   providers: [NewsService],

--- a/src/app/components/cookie-banner/cookie-banner.component.html
+++ b/src/app/components/cookie-banner/cookie-banner.component.html
@@ -1,0 +1,10 @@
+<div class="banner" *ngIf="consent.needsConsent() && !consent.hasConsent()">
+  <p>
+    We use cookies to personalize content and analyze our traffic. Please
+    select your preferences.
+  </p>
+  <button (click)="acceptAll()">Accept All</button>
+  <button (click)="rejectAll()">Reject All</button>
+  <button (click)="customize()">Customize</button>
+  <a routerLink="/cookie-policy">Cookie Policy</a>
+</div>

--- a/src/app/components/cookie-banner/cookie-banner.component.scss
+++ b/src/app/components/cookie-banner/cookie-banner.component.scss
@@ -1,0 +1,18 @@
+.banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #fafafa;
+  border-top: 1px solid #ccc;
+  padding: 1rem;
+  text-align: center;
+  box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+}
+.banner button {
+  margin: 0 0.5rem;
+}
+.banner a {
+  display: inline-block;
+  margin-left: 1rem;
+}

--- a/src/app/components/cookie-banner/cookie-banner.component.ts
+++ b/src/app/components/cookie-banner/cookie-banner.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { CookieConsentService } from '../../services/cookie-consent.service';
+
+@Component({
+  selector: 'app-cookie-banner',
+  templateUrl: './cookie-banner.component.html',
+  styleUrls: ['./cookie-banner.component.scss']
+})
+export class CookieBannerComponent {
+  constructor(public consent: CookieConsentService, private router: Router) {}
+
+  acceptAll(): void {
+    this.consent.savePreferences({ analytics: true, marketing: true });
+  }
+
+  rejectAll(): void {
+    this.consent.savePreferences({ analytics: false, marketing: false });
+  }
+
+  customize(): void {
+    this.router.navigate(['/cookie-settings']);
+  }
+}

--- a/src/app/components/cookie-policy/cookie-policy.component.html
+++ b/src/app/components/cookie-policy/cookie-policy.component.html
@@ -1,0 +1,7 @@
+<h2>Cookie Policy</h2>
+<p>
+  We use cookies to provide essential site functions and to understand how our
+  site is used. Analytics and marketing cookies are optional and require your
+  consent. Collected data is used solely for improving the site and is never
+  sold. Cookies expire after six months.
+</p>

--- a/src/app/components/cookie-policy/cookie-policy.component.scss
+++ b/src/app/components/cookie-policy/cookie-policy.component.scss
@@ -1,0 +1,6 @@
+h2 {
+  margin: 1rem;
+}
+p {
+  padding: 0 1rem 1rem;
+}

--- a/src/app/components/cookie-policy/cookie-policy.component.ts
+++ b/src/app/components/cookie-policy/cookie-policy.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-cookie-policy',
+  templateUrl: './cookie-policy.component.html',
+  styleUrls: ['./cookie-policy.component.scss']
+})
+export class CookiePolicyComponent {}

--- a/src/app/components/cookie-settings/cookie-settings.component.html
+++ b/src/app/components/cookie-settings/cookie-settings.component.html
@@ -1,0 +1,12 @@
+<h2>Cookie Preferences</h2>
+<form (ngSubmit)="save()">
+  <label>
+    <input type="checkbox" [(ngModel)]="analytics" name="analytics" /> Allow analytics cookies
+  </label>
+  <br />
+  <label>
+    <input type="checkbox" [(ngModel)]="marketing" name="marketing" /> Allow marketing cookies
+  </label>
+  <br />
+  <button type="submit">Save</button>
+</form>

--- a/src/app/components/cookie-settings/cookie-settings.component.scss
+++ b/src/app/components/cookie-settings/cookie-settings.component.scss
@@ -1,0 +1,7 @@
+form {
+  padding: 1rem;
+}
+label {
+  display: block;
+  margin: 0.5rem 0;
+}

--- a/src/app/components/cookie-settings/cookie-settings.component.ts
+++ b/src/app/components/cookie-settings/cookie-settings.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { CookieConsentService } from '../../services/cookie-consent.service';
+
+@Component({
+  selector: 'app-cookie-settings',
+  templateUrl: './cookie-settings.component.html',
+  styleUrls: ['./cookie-settings.component.scss']
+})
+export class CookieSettingsComponent {
+  analytics = true;
+  marketing = true;
+
+  constructor(private consent: CookieConsentService, private router: Router) {
+    const prefs = consent.getPreferences();
+    if (prefs) {
+      this.analytics = prefs.analytics;
+      this.marketing = prefs.marketing;
+    }
+  }
+
+  save(): void {
+    this.consent.savePreferences({ analytics: this.analytics, marketing: this.marketing });
+    this.router.navigate(['/']);
+  }
+}

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,3 +1,4 @@
 <footer>
-  <p>&copy; 2024 News App</p>
+  <p>&copy; 2024 News App | <a routerLink="/cookie-policy">Cookie Policy</a> |
+    <a routerLink="/cookie-settings">Manage Cookies</a></p>
 </footer>

--- a/src/app/services/cookie-consent.service.ts
+++ b/src/app/services/cookie-consent.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@angular/core';
+
+export interface CookiePreferences {
+  essential: boolean;
+  analytics: boolean;
+  marketing: boolean;
+  timestamp: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CookieConsentService {
+  private regionKey = 'userRegion';
+  private prefsKey = 'cookiePrefs';
+  region: string | null = null;
+  preferences: CookiePreferences | null = null;
+
+  constructor() {
+    this.load();
+  }
+
+  private load(): void {
+    this.region = localStorage.getItem(this.regionKey);
+    const p = localStorage.getItem(this.prefsKey);
+    this.preferences = p ? (JSON.parse(p) as CookiePreferences) : null;
+    if (!this.region) {
+      this.region = this.detectRegion();
+      localStorage.setItem(this.regionKey, this.region);
+    }
+    if (this.preferences && this.isExpired(this.preferences)) {
+      this.preferences = null;
+      localStorage.removeItem(this.prefsKey);
+    }
+  }
+
+  private isExpired(prefs: CookiePreferences): boolean {
+    const SIX_MONTHS = 1000 * 60 * 60 * 24 * 30 * 6;
+    return Date.now() - prefs.timestamp > SIX_MONTHS;
+  }
+
+  detectRegion(): string {
+    try {
+      const locale = navigator.language || '';
+      const region = new Intl.Locale(locale).region?.toUpperCase() || '';
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+      const eu = [
+        'AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE'
+      ];
+      if (region === 'BR') {
+        return 'brazil';
+      }
+      if (region === 'GB' || region === 'UK') {
+        return 'uk';
+      }
+      if (region === 'US') {
+        if (tz.includes('Los_Angeles')) {
+          return 'california';
+        }
+        return 'us';
+      }
+      if (eu.includes(region)) {
+        return 'eu';
+      }
+    } catch (e) {
+      // ignore
+    }
+    return 'other';
+  }
+
+  needsConsent(): boolean {
+    return (
+      this.region === 'eu' ||
+      this.region === 'uk' ||
+      this.region === 'brazil' ||
+      this.region === 'california'
+    );
+  }
+
+  hasConsent(): boolean {
+    return this.preferences !== null;
+  }
+
+  savePreferences(prefs: { analytics: boolean; marketing: boolean }): void {
+    this.preferences = {
+      essential: true,
+      analytics: prefs.analytics,
+      marketing: prefs.marketing,
+      timestamp: Date.now(),
+    };
+    localStorage.setItem(this.prefsKey, JSON.stringify(this.preferences));
+  }
+
+  getPreferences(): CookiePreferences | null {
+    return this.preferences;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `CookieConsentService` to handle region detection and preferences
- create cookie banner with accept/reject/customize options
- add cookie settings and policy pages
- update footer links and app routes

## Testing
- `npm test` *(fails: ChromeHeadless not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873f80ea7248329b88b9b4424f62884