### PR TITLE
Add cookie consent banner and settings

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,4 @@
 <app-header></app-header>
 <router-outlet></router-outlet>
 <app-footer></app-footer>
+<app-cookie-consent></app-cookie-consent>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,10 @@ import { ViennaNewsComponent } from './components/vienna-news/vienna-news.compon
 import { LocalNewsDetailComponent } from './components/local-news-detail/local-news-detail.component';
 import { WeatherComponent } from './components/weather/weather.component';
 import { MailmanLoaderComponent } from './components/mailman-loader/mailman-loader.component';
+import { CookieConsentComponent } from './components/cookie-consent/cookie-consent.component';
+import { CookieSettingsComponent } from './components/cookie-settings/cookie-settings.component';
+import { CookiePolicyComponent } from './components/cookie-policy/cookie-policy.component';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -28,18 +32,24 @@ import { MailmanLoaderComponent } from './components/mailman-loader/mailman-load
     ViennaNewsComponent,
     LocalNewsDetailComponent,
     WeatherComponent,
-    MailmanLoaderComponent
+    MailmanLoaderComponent,
+    CookieConsentComponent,
+    CookieSettingsComponent,
+    CookiePolicyComponent
   ],
   imports: [
     BrowserModule,
     HttpClientModule,
+    FormsModule,
     AngularFireModule.initializeApp(environment.firebase),
     AngularFirestoreModule,
     RouterModule.forRoot([
       { path: '', redirectTo: 'local-news/vienna', pathMatch: 'full' },
       { path: 'news/:id', component: NewsDetailComponent },
       { path: 'local-news/vienna', component: ViennaNewsComponent },
-      { path: 'local-news/vienna/:id', component: LocalNewsDetailComponent }
+      { path: 'local-news/vienna/:id', component: LocalNewsDetailComponent },
+      { path: 'cookie-settings', component: CookieSettingsComponent },
+      { path: 'cookie-policy', component: CookiePolicyComponent }
     ])
   ],
   providers: [NewsService],

--- a/src/app/components/cookie-consent/cookie-consent.component.html
+++ b/src/app/components/cookie-consent/cookie-consent.component.html
@@ -1,0 +1,12 @@
+<div class="cookie-banner" *ngIf="(consent.showBanner$ | async)">
+  <p>
+    We use cookies to personalize content and ads, to provide social media features and to
+    analyze our traffic. You can manage your preferences.
+  </p>
+  <div class="actions">
+    <button class="accept" (click)="acceptAll()">Accept all</button>
+    <button class="reject" (click)="rejectAll()">Reject all</button>
+    <button class="customize" (click)="customize()">Customize</button>
+  </div>
+  <a routerLink="/cookie-policy" class="policy-link">Learn more</a>
+</div>

--- a/src/app/components/cookie-consent/cookie-consent.component.scss
+++ b/src/app/components/cookie-consent/cookie-consent.component.scss
@@ -1,0 +1,52 @@
+.cookie-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--color-surface);
+  color: var(--text-primary);
+  padding: 1rem;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  z-index: 20;
+}
+
+.cookie-banner p {
+  margin: 0;
+  text-align: center;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.actions button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.accept {
+  background: var(--color-secondary);
+  color: #fff;
+}
+
+.reject {
+  background: #ccc;
+  color: #333;
+}
+
+.customize {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.policy-link {
+  color: var(--color-secondary);
+  text-decoration: underline;
+}

--- a/src/app/components/cookie-consent/cookie-consent.component.ts
+++ b/src/app/components/cookie-consent/cookie-consent.component.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { CookieConsentService } from '../../services/cookie-consent.service';
+
+@Component({
+  selector: 'app-cookie-consent',
+  templateUrl: './cookie-consent.component.html',
+  styleUrls: ['./cookie-consent.component.scss']
+})
+export class CookieConsentComponent {
+  constructor(
+    public consent: CookieConsentService,
+    private router: Router
+  ) {}
+
+  acceptAll(): void {
+    this.consent.acceptAll();
+  }
+
+  rejectAll(): void {
+    this.consent.rejectAll();
+  }
+
+  customize(): void {
+    this.router.navigate(['/cookie-settings']);
+  }
+}

--- a/src/app/components/cookie-policy/cookie-policy.component.html
+++ b/src/app/components/cookie-policy/cookie-policy.component.html
@@ -1,0 +1,9 @@
+<div class="policy">
+  <h1>Cookie Policy</h1>
+  <p>
+    This page explains how and why we use cookies. We only use analytics and marketing cookies with your consent.
+  </p>
+  <p>
+    For more details about the data we collect and how long we store it, please contact us.
+  </p>
+</div>

--- a/src/app/components/cookie-policy/cookie-policy.component.scss
+++ b/src/app/components/cookie-policy/cookie-policy.component.scss
@@ -1,0 +1,7 @@
+.policy {
+  max-width: 800px;
+  margin: 2rem auto;
+  background: var(--color-surface);
+  padding: 1rem;
+  border-radius: 4px;
+}

--- a/src/app/components/cookie-policy/cookie-policy.component.ts
+++ b/src/app/components/cookie-policy/cookie-policy.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-cookie-policy',
+  templateUrl: './cookie-policy.component.html',
+  styleUrls: ['./cookie-policy.component.scss']
+})
+export class CookiePolicyComponent {}

--- a/src/app/components/cookie-settings/cookie-settings.component.html
+++ b/src/app/components/cookie-settings/cookie-settings.component.html
@@ -1,0 +1,19 @@
+<div class="cookie-settings">
+  <h2>Manage Cookie Preferences</h2>
+  <p>Update how we use cookies on this site.</p>
+  <form (ngSubmit)="save()">
+    <label>
+      <input type="checkbox" disabled checked />
+      <span>Essential cookies (always enabled)</span>
+    </label>
+    <label>
+      <input type="checkbox" [(ngModel)]="prefs.analytics" name="analytics" />
+      <span>Analytics cookies</span>
+    </label>
+    <label>
+      <input type="checkbox" [(ngModel)]="prefs.marketing" name="marketing" />
+      <span>Marketing cookies</span>
+    </label>
+    <button type="submit">Save preferences</button>
+  </form>
+</div>

--- a/src/app/components/cookie-settings/cookie-settings.component.scss
+++ b/src/app/components/cookie-settings/cookie-settings.component.scss
@@ -1,0 +1,24 @@
+.cookie-settings {
+  max-width: 600px;
+  margin: 2rem auto;
+  background: var(--color-surface);
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-secondary);
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}

--- a/src/app/components/cookie-settings/cookie-settings.component.ts
+++ b/src/app/components/cookie-settings/cookie-settings.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { CookieConsentService, CookiePreferences } from '../../services/cookie-consent.service';
+
+@Component({
+  selector: 'app-cookie-settings',
+  templateUrl: './cookie-settings.component.html',
+  styleUrls: ['./cookie-settings.component.scss']
+})
+export class CookieSettingsComponent {
+  prefs: CookiePreferences = { analytics: false, marketing: false };
+
+  constructor(private consent: CookieConsentService, private router: Router) {
+    const saved = this.consent.getPreferences();
+    if (saved) {
+      this.prefs = { ...saved };
+    }
+  }
+
+  save(): void {
+    this.consent.savePreferences(this.prefs);
+    this.router.navigate(['/']);
+  }
+}

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,3 +1,3 @@
 <footer>
-  <p>&copy; 2024 News App</p>
+  <p>&copy; 2024 News App | <a routerLink="/cookie-settings">Cookie Settings</a> | <a routerLink="/cookie-policy">Cookie Policy</a></p>
 </footer>

--- a/src/app/services/cookie-consent.service.ts
+++ b/src/app/services/cookie-consent.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+
+export interface CookiePreferences {
+  analytics: boolean;
+  marketing: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CookieConsentService {
+  private readonly regionKey = 'user_region';
+  private readonly prefsKey = 'cookie_preferences';
+  private readonly consentTimestampKey = 'cookie_consent_timestamp';
+  private readonly consentExpiryDays = 180; // ~6 months
+  private showBannerSubject = new BehaviorSubject<boolean>(false);
+  showBanner$ = this.showBannerSubject.asObservable();
+
+  private preferredRegion?: string;
+
+  constructor(private http: HttpClient) {
+    this.init();
+  }
+
+  /** Initialize by checking region and preferences */
+  private init(): void {
+    const prefs = this.getPreferences();
+    if (prefs && !this.isConsentExpired()) {
+      return; // preferences exist and not expired
+    }
+
+    const region = localStorage.getItem(this.regionKey);
+    if (region) {
+      this.preferredRegion = region;
+      if (this.consentRequired(region)) {
+        this.showBannerSubject.next(true);
+      }
+    } else {
+      this.detectRegion().subscribe(r => {
+        this.preferredRegion = r;
+        if (this.consentRequired(r)) {
+          this.showBannerSubject.next(true);
+        }
+      });
+    }
+  }
+
+  private detectRegion(): Observable<string> {
+    return this.http.get<any>('https://ipapi.co/json/').pipe(
+      tap(res => {
+        localStorage.setItem(this.regionKey, res.country_code || '');
+        if (res.region_code) {
+          localStorage.setItem('user_region_state', res.region_code);
+        }
+      }),
+      catchError(() => {
+        localStorage.setItem(this.regionKey, '');
+        return of('');
+      })
+    );
+  }
+
+  private consentRequired(region: string): boolean {
+    const requiredRegions = ['EU', 'GB', 'BR', 'CA'];
+    if (region === 'US') {
+      // For US, only California (CA) has stricter requirements.
+      const state = localStorage.getItem('user_region_state');
+      return state === 'CA';
+    }
+    return requiredRegions.includes(region);
+  }
+
+  acceptAll(): void {
+    this.savePreferences({ analytics: true, marketing: true });
+  }
+
+  rejectAll(): void {
+    this.savePreferences({ analytics: false, marketing: false });
+  }
+
+  savePreferences(prefs: CookiePreferences): void {
+    localStorage.setItem(this.prefsKey, JSON.stringify(prefs));
+    localStorage.setItem(this.consentTimestampKey, Date.now().toString());
+    this.showBannerSubject.next(false);
+  }
+
+  getPreferences(): CookiePreferences | null {
+    const str = localStorage.getItem(this.prefsKey);
+    if (!str) { return null; }
+    try {
+      return JSON.parse(str) as CookiePreferences;
+    } catch {
+      return null;
+    }
+  }
+
+  private isConsentExpired(): boolean {
+    const ts = localStorage.getItem(this.consentTimestampKey);
+    if (!ts) { return true; }
+    const diff = Date.now() - parseInt(ts, 10);
+    return diff > this.consentExpiryDays * 24 * 60 * 60 * 1000;
+  }
+}


### PR DESCRIPTION
## Summary
- add a region-aware `CookieConsentService`
- show new `CookieConsentComponent` banner
- add cookie settings and policy pages
- update footer links
- register cookie components and routes

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6874093eab9c83299536b191e8e602c8