### PR TITLE
Improve detail page caching and image layout

### DIFF
--- a/src/app/components/local-news-detail/local-news-detail.component.scss
+++ b/src/app/components/local-news-detail/local-news-detail.component.scss
@@ -3,8 +3,12 @@
 }
 
 .local-news-detail img {
+  display: block;
+  width: 80vw;
+  height: 40vh;
   max-width: 100%;
-  margin-bottom: 1rem;
+  object-fit: cover;
+  margin: 0 auto 1rem;
 }
 
 .meta {

--- a/src/app/components/local-news-detail/local-news-detail.component.ts
+++ b/src/app/components/local-news-detail/local-news-detail.component.ts
@@ -16,7 +16,8 @@ export class LocalNewsDetailComponent implements OnInit {
   constructor(private route: ActivatedRoute, private router: Router, private service: LocalNewsService) {}
 
   ngOnInit(): void {
-    const stateArticle = this.router.getCurrentNavigation()?.extras.state?.['article'] as LocalNewsArticle | undefined;
+    const navigationState = this.router.getCurrentNavigation()?.extras.state as { article?: LocalNewsArticle } | undefined;
+    const stateArticle = navigationState?.article || (history.state && history.state['article']) as LocalNewsArticle | undefined;
     const id = this.route.snapshot.paramMap.get('id');
 
     if (stateArticle) {

--- a/src/app/components/news-detail/news-detail.component.ts
+++ b/src/app/components/news-detail/news-detail.component.ts
@@ -20,7 +20,8 @@ export class NewsDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const stateNews = this.router.getCurrentNavigation()?.extras.state?.['article'] as News | undefined;
+    const navigationState = this.router.getCurrentNavigation()?.extras.state as { article?: News } | undefined;
+    const stateNews = navigationState?.article || (history.state && history.state['article']) as News | undefined;
     const id = this.route.snapshot.paramMap.get('id');
 
     if (stateNews) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -99,8 +99,12 @@ nav a:hover {
 }
 
 .news-detail img {
+  display: block;
+  width: 80vw;
+  height: 40vh;
   max-width: 100%;
-  height: auto;
+  object-fit: cover;
+  margin: 0 auto;
 }
 
 .accent {


### PR DESCRIPTION
## Summary
- reuse article data passed via router state or history to avoid extra fetches on news detail pages
- size detail view images relative to the viewport for consistent rendering

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6874300d26788329849b1b3b7c8d88b2