### PR TITLE
Show news tags

### DIFF
--- a/src/app/components/local-news-detail/local-news-detail.component.html
+++ b/src/app/components/local-news-detail/local-news-detail.component.html
@@ -2,6 +2,7 @@
 <div class="local-news-detail" *ngIf="article$ | async as article">
   <h2>{{article.title_long}}</h2>
   <img [src]="article.image" alt="{{article.title_long}}">
+  <p class="tag" *ngIf="article.tag">{{article.tag}}</p>
   <p class="summary">{{article.desc_long}}</p>
   <p class="meta">Added: {{article.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{article.views}}</p>
 </div>

--- a/src/app/components/local-news-detail/local-news-detail.component.scss
+++ b/src/app/components/local-news-detail/local-news-detail.component.scss
@@ -1,14 +1,36 @@
 .local-news-detail {
   padding: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.local-news-detail h2 {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+  color: #d62828;
 }
 
 .local-news-detail img {
   display: block;
-  width: 80vw;
-  height: 40vh;
-  max-width: 100%;
+  width: 100%;
+  max-height: 400px;
   object-fit: cover;
-  margin: 0 auto 1rem;
+  margin: 0 auto 0.5rem;
+}
+
+.local-news-detail .tag {
+  display: inline-block;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 2px;
+  margin-bottom: 1rem;
+}
+
+.local-news-detail .summary {
+  line-height: 1.6;
+  margin-bottom: 1rem;
 }
 
 .meta {

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -1,4 +1,5 @@
 <div class="news-card" (click)="open()">
+  <span class="tag" *ngIf="article.tag">{{article.tag}}</span>
   <div class="image-wrapper">
     <img [src]="article.image" alt="{{article.title_short}}" />
   </div>

--- a/src/app/components/news-card/news-card.component.scss
+++ b/src/app/components/news-card/news-card.component.scss
@@ -1,4 +1,5 @@
 .news-card {
+  position: relative;
   background: #fff;
   border: 1px solid #dee2e6;
   overflow: hidden;
@@ -56,4 +57,15 @@
 .meta {
   font-size: 0.75rem;
   color: #6c757d;
+}
+
+.tag {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 2px;
 }

--- a/src/app/components/news-detail/news-detail.component.html
+++ b/src/app/components/news-detail/news-detail.component.html
@@ -2,6 +2,7 @@
 <div class="news-detail" *ngIf="news$ | async as news">
   <h2>{{news.title_long}}</h2>
   <img [src]="news.bigImage || news.image" alt="{{news.title_long}}">
+  <p class="tag" *ngIf="news.tag">{{news.tag}}</p>
   <p class="summary">{{news.desc_long}}</p>
   <p class="meta">Added: {{news.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{news.views}}</p>
 </div>

--- a/src/app/components/news-detail/news-detail.component.scss
+++ b/src/app/components/news-detail/news-detail.component.scss
@@ -1,4 +1,38 @@
-/* additional detail styles */
+.news-detail {
+  padding: 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.news-detail h2 {
+  font-size: 1.75rem;
+  margin-bottom: 0.5rem;
+  color: #d62828;
+}
+
+.news-detail img {
+  display: block;
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  margin: 0 auto 0.5rem;
+}
+
+.news-detail .tag {
+  display: inline-block;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 2px;
+  margin-bottom: 1rem;
+}
+
+.news-detail .summary {
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
 .meta {
   font-size: 0.875rem;
   color: #6c757d;

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -1,5 +1,6 @@
 <div class="top-stories">
   <div class="story" *ngFor="let s of stories" (click)="open(s)">
+    <span class="tag" *ngIf="s.tag">{{s.tag}}</span>
     <img [src]="s.image" alt="{{s.title_short}}" />
     <h2>{{s.title_short}}</h2>
     <small class="story-meta">Added: {{s.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{s.views}}</small>

--- a/src/app/components/top-stories/top-stories.component.scss
+++ b/src/app/components/top-stories/top-stories.component.scss
@@ -46,3 +46,15 @@
   color: #fff;
   font-size: 0.75rem;
 }
+
+.tag {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 2px;
+  z-index: 1;
+}

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -12,6 +12,8 @@ export interface News {
   desc_long: string;
   image: string;
   bigImage?: string;
+  /** Optional tag or category for the article */
+  tag?: string;
   created_at: any;
   views: number;
 }


### PR DESCRIPTION
## Summary
- add optional `tag` field to `News` model
- display tag on news cards and top stories
- show tag in news detail views under the image
- refresh styles for detail pages

## Testing
- `npm test` *(fails: no Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_687d41ebf4e8832998650ce5b8361f10