### PR TITLE
Improve mobile titles

### DIFF
--- a/src/app/components/news-card/news-card.component.scss
+++ b/src/app/components/news-card/news-card.component.scss
@@ -47,6 +47,17 @@
   margin: 0;
 }
 
+@media (max-width: 768px) {
+  .title {
+    /* Clamp to two lines on small screens */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+}
+
 .summary {
   font-size: 0.875rem;
   line-height: 1.5;

--- a/src/app/components/top-stories/top-stories.component.scss
+++ b/src/app/components/top-stories/top-stories.component.scss
@@ -32,6 +32,17 @@
   font-size: 1.5rem;
 }
 
+@media (max-width: 768px) {
+  .story h2 {
+    /* Limit title height and show ellipsis if text wraps */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+}
+
 .story:hover img {
   transform: scale(1.05);
 }


### PR DESCRIPTION
## Summary
- clamp news card titles for long mobile lines
- clamp top story titles on mobile

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_687d416164b48329ae96fc86a21c0c5e