### PR TITLE
Implement ellipsis for long headlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ This is a simple Angular application that displays news articles fetched from a 
    ```
 
 The application is structured with reusable components. Both the `NewsService` and `LocalNewsService` load articles from the same `news` collection in Firestore. A demo Firebase configuration is already provided in the environment files, but you can replace it with your own project settings if desired.
+
+## Tags
+
+Articles may include an optional `tag` field. Tags appear as small labels on the home page and in the article detail view.

--- a/src/app/components/news-card/news-card.component.html
+++ b/src/app/components/news-card/news-card.component.html
@@ -1,6 +1,7 @@
 <div class="news-card" (click)="open()">
   <div class="image-wrapper">
     <img [src]="article.image" alt="{{article.title_short}}" />
+    <span class="tag" *ngIf="article.tag">{{article.tag}}</span>
   </div>
   <div class="card-body">
     <h3 class="title">{{article.title_short}}</h3>

--- a/src/app/components/news-card/news-card.component.scss
+++ b/src/app/components/news-card/news-card.component.scss
@@ -14,6 +14,18 @@
   padding-top: 56.25%;
 }
 
+.tag {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
 .image-wrapper img {
   position: absolute;
   top: 0;
@@ -45,6 +57,11 @@
   font-weight: 700;
   color: #d62828;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .summary {

--- a/src/app/components/news-detail/news-detail.component.html
+++ b/src/app/components/news-detail/news-detail.component.html
@@ -2,6 +2,7 @@
 <div class="news-detail" *ngIf="news$ | async as news">
   <h2>{{news.title_long}}</h2>
   <img [src]="news.bigImage || news.image" alt="{{news.title_long}}">
+  <span class="tag" *ngIf="news.tag">{{news.tag}}</span>
   <p class="meta">Added: {{news.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{news.views}}</p>
     <p></p>
     <p class="summary">{{news.desc_long}}</p>

--- a/src/app/components/news-detail/news-detail.component.scss
+++ b/src/app/components/news-detail/news-detail.component.scss
@@ -3,3 +3,26 @@
   font-size: 0.875rem;
   color: #6c757d;
 }
+
+.news-detail {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.news-detail img {
+  width: 100%;
+  height: auto;
+  margin-bottom: 0.5rem;
+}
+
+.tag {
+  display: inline-block;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}

--- a/src/app/components/top-stories/top-stories.component.html
+++ b/src/app/components/top-stories/top-stories.component.html
@@ -1,6 +1,7 @@
 <div class="top-stories">
   <div class="story" *ngFor="let s of stories" (click)="open(s)">
     <img [src]="s.image" alt="{{s.title_short}}" />
+    <span class="tag" *ngIf="s.tag">{{s.tag}}</span>
     <h2>{{s.title_short}}</h2>
     <small class="story-meta">Added: {{s.created_at | date:'yyyy-MM-dd hh:mm a'}} | Views: {{s.views}}</small>
   </div>

--- a/src/app/components/top-stories/top-stories.component.scss
+++ b/src/app/components/top-stories/top-stories.component.scss
@@ -30,6 +30,11 @@
   background: rgba(33, 37, 41, 0.6);
   color: #fff;
   font-size: 1.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .story:hover img {
@@ -45,4 +50,16 @@
   background: rgba(33, 37, 41, 0.6);
   color: #fff;
   font-size: 0.75rem;
+}
+
+.tag {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: #d62828;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  text-transform: uppercase;
 }

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -11,6 +11,7 @@ export interface News {
   title_long: string;
   desc_long: string;
   image: string;
+  tag?: string;
   bigImage?: string;
   created_at: any;
   views: number;


### PR DESCRIPTION
## Summary
- merge latest master into work
- preserve ellipsis styling for truncated news titles

## Testing
- `npm test` *(fails: ChromeHeadless missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d5dd201308329aef59f787c710e98