### PR TITLE
Add tag-based top stories and paginated feed

### DIFF
--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -2,9 +2,22 @@
   <app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
   <h1 class="page-title">Vienna Local News</h1>
   <app-top-stories [stories]="topStories"></app-top-stories>
+  <div class="pagination-controls">
+    <label>
+      Items per page:
+      <select [(ngModel)]="itemsPerPage" (ngModelChange)="setItemsPerPage($event)">
+        <option *ngFor="let s of pageSizes" [value]="s">{{s}}</option>
+      </select>
+    </label>
+  </div>
   <div class="content-grid">
     <div class="news-feed">
-      <app-news-card *ngFor="let n of feed" [article]="n"></app-news-card>
+      <app-news-card *ngFor="let n of paginatedFeed" [article]="n"></app-news-card>
+      <div class="pager">
+        <button (click)="prevPage()" [disabled]="currentPage === 1">Prev</button>
+        <span>Page {{currentPage}} / {{totalPages}}</span>
+        <button (click)="nextPage()" [disabled]="currentPage === totalPages">Next</button>
+      </div>
     </div>
     <aside class="sidebar">
       <div class="weather-widget">

--- a/src/app/components/vienna-news/vienna-news.component.scss
+++ b/src/app/components/vienna-news/vienna-news.component.scss
@@ -25,6 +25,18 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: 1rem;
+  .pager {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
+}
+
+.pagination-controls {
+  margin: 1rem 0;
 }
 
 .sidebar {

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -12,6 +12,8 @@ export interface News {
   desc_long: string;
   image: string;
   bigImage?: string;
+  /** Optional list of tags describing the news item. */
+  tags?: string[];
   created_at: any;
   views: number;
 }


### PR DESCRIPTION
## Summary
- select top stories by `top` tag
- sort non-top stories by newest first
- paginate news feed with configurable page size
- expose page size options 5/10/15/30

## Testing
- `npm test -- --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_687d6064363c8329b03fd76d40a640b6