### PR TITLE
Implement tag-based top news and pagination

### DIFF
--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -6,7 +6,17 @@
   <div class="content-grid">
       <app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
     <div class="news-feed">
-      <app-news-card *ngFor="let n of feed" [article]="n"></app-news-card>
+      <app-news-card *ngFor="let n of pagedFeed" [article]="n"></app-news-card>
+      <div class="pagination-controls" *ngIf="feed.length">
+        <label>Items per page:
+          <select [ngModel]="itemsPerPage" (ngModelChange)="onPerPageChange($event)">
+            <option *ngFor="let opt of itemsPerPageOptions" [value]="opt">{{opt}}</option>
+          </select>
+        </label>
+        <button (click)="prevPage()" [disabled]="currentPage === 1">Prev</button>
+        <span>Page {{currentPage}} / {{totalPages}}</span>
+        <button (click)="nextPage()" [disabled]="currentPage === totalPages">Next</button>
+      </div>
     </div>
     <aside class="sidebar">
       <div class="weather-widget">

--- a/src/app/components/vienna-news/vienna-news.component.scss
+++ b/src/app/components/vienna-news/vienna-news.component.scss
@@ -39,6 +39,13 @@
   top: 1rem;
 }
 
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
 @media (max-width: 768px) {
   .content-grid {
     grid-template-columns: 1fr;

--- a/src/app/components/vienna-news/vienna-news.component.ts
+++ b/src/app/components/vienna-news/vienna-news.component.ts
@@ -13,6 +13,10 @@ export class ViennaNewsComponent implements OnInit {
   loading = true;
   error = false;
 
+  itemsPerPageOptions = [5, 10, 15, 30];
+  itemsPerPage = this.itemsPerPageOptions[1];
+  currentPage = 1;
+
   constructor(private news: NewsService) {}
 
   ngOnInit(): void {
@@ -21,8 +25,11 @@ export class ViennaNewsComponent implements OnInit {
       .pipe(first())
       .subscribe({
         next: all => {
-          this.topStories = all.slice(0, 3);
-          this.feed = all.slice(3);
+          const topTag = 'top';
+          this.topStories = all.filter(a => a.tag?.toLowerCase() === topTag);
+          this.feed = all
+            .filter(a => a.tag?.toLowerCase() !== topTag)
+            .sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
           this.loading = false;
         },
         error: () => {
@@ -30,5 +37,31 @@ export class ViennaNewsComponent implements OnInit {
           this.error = true;
         }
       });
+  }
+
+  get pagedFeed(): News[] {
+    const start = (this.currentPage - 1) * this.itemsPerPage;
+    return this.feed.slice(start, start + this.itemsPerPage);
+  }
+
+  get totalPages(): number {
+    return Math.ceil(this.feed.length / this.itemsPerPage) || 1;
+  }
+
+  nextPage(): void {
+    if (this.currentPage < this.totalPages) {
+      this.currentPage++;
+    }
+  }
+
+  prevPage(): void {
+    if (this.currentPage > 1) {
+      this.currentPage--;
+    }
+  }
+
+  onPerPageChange(val: number) {
+    this.itemsPerPage = val;
+    this.currentPage = 1;
   }
 }

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -34,7 +34,7 @@ export class NewsService {
 
   getNews(): Observable<News[]> {
     return this.firestore
-      .collection<News>('news')
+      .collection<News>('news', ref => ref.orderBy('created_at', 'desc'))
       .valueChanges({ idField: 'id' })
       .pipe(map(list => list.map(n => this.normalizeArticle(n))));
   }


### PR DESCRIPTION
## Summary
- pull news from Firestore ordered by creation date
- filter top news using the `top` tag
- sort remaining news by date and paginate
- allow user to choose items per page (5,10,15,30)
- add pagination controls styles

## Testing
- `npm test -- --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_687d66562bfc8329a7e4f41add24ac15