### PR TITLE
Implement backend pagination

### DIFF
--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -6,7 +6,7 @@
   <div class="content-grid">
       <app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
     <div class="news-feed">
-      <app-news-card *ngFor="let n of pagedFeed" [article]="n"></app-news-card>
+      <app-news-card *ngFor="let n of feed" [article]="n"></app-news-card>
       <div class="pagination-controls" *ngIf="feed.length">
         <label>Items per page:
           <select [ngModel]="itemsPerPage" (ngModelChange)="onPerPageChange($event)">

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -39,6 +39,28 @@ export class NewsService {
       .pipe(map(list => list.map(n => this.normalizeArticle(n))));
   }
 
+  getTopNews(limit = 5): Observable<News[]> {
+    return this.firestore
+      .collection<News>('news', ref =>
+        ref.where('tag', '==', 'top').orderBy('created_at', 'desc').limit(limit)
+      )
+      .valueChanges({ idField: 'id' })
+      .pipe(map(list => list.map(n => this.normalizeArticle(n))));
+  }
+
+  getNewsPage(pageSize: number, startAfterDate: Date | null): Observable<News[]> {
+    return this.firestore
+      .collection<News>('news', ref => {
+        let query = ref.orderBy('created_at', 'desc').limit(pageSize);
+        if (startAfterDate) {
+          query = query.startAfter(startAfterDate);
+        }
+        return query;
+      })
+      .valueChanges({ idField: 'id' })
+      .pipe(map(list => list.map(n => this.normalizeArticle(n))));
+  }
+
   getNewsById(id: string): Observable<News> {
     return this.firestore
       .collection<News>('news')


### PR DESCRIPTION
## Summary
- add `getNewsPage` and `getTopNews` methods
- load paged data from backend in ViennaNewsComponent
- update template to render only the fetched page

## Testing
- `npm test --silent -- --no-watch --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_687d6ea9e46c8329a4a4f4ed91217523