### PR TITLE
Implement total news count caching for pagination

### DIFF
--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -68,4 +68,11 @@ export class NewsService {
       .valueChanges({ idField: 'id' })
       .pipe(map(n => (n ? this.normalizeArticle(n) : (n as any))));
   }
+
+  getNewsCount(): Observable<number> {
+    return this.firestore
+      .collection<News>('news')
+      .get()
+      .pipe(map(snapshot => snapshot.size));
+  }
 }


### PR DESCRIPTION
## Summary
- add `getNewsCount` method to `NewsService`
- cache news count in localStorage and compute total pages
- recalc page count when items per page changes and jump to first page

## Testing
- `npm test` *(fails: ChromeHeadless not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dcd3351d48329a7d4925a5eeefb1a