### PR TITLE
Add category pages and navbar links

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,7 +42,8 @@ import { CookiePolicyComponent } from './components/cookie-policy/cookie-policy.
     AngularFireModule.initializeApp(environment.firebase),
     AngularFirestoreModule,
     RouterModule.forRoot([
-      { path: '',component: ViennaNewsComponent, pathMatch: 'full' },
+      { path: '', component: ViennaNewsComponent, pathMatch: 'full' },
+      { path: 'category/:tag', component: ViennaNewsComponent },
       { path: 'cookie-settings', component: CookieSettingsComponent },
       { path: 'cookie-policy', component: CookiePolicyComponent },
       { path: ':id', component: NewsDetailComponent }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,6 +1,6 @@
 <header [class.hidden]="isHidden">
   <div class="top-bar">
-    <div class="branding">
+    <a routerLink="/" class="branding" aria-label="Home">
       <span class="logo" aria-hidden="true">
         <svg viewBox="0 0 24 24" width="24" height="24">
           <circle cx="12" cy="12" r="10" fill="currentColor" />
@@ -8,7 +8,7 @@
         </svg>
       </span>
       <span class="site-title">News App</span>
-    </div>
+    </a>
 
     <button class="menu-toggle" aria-label="Toggle navigation" (click)="toggleMenu()">
       <span></span>
@@ -16,9 +16,9 @@
       <span></span>
     </button>
     <nav class="main-nav" [class.open]="isMenuOpen" (click)="closeMenu()">
-      <a href="#">Region</a>
-      <a href="#">Sport</a>
-      <a href="#">Business</a>
+      <a routerLink="/category/region">Region</a>
+      <a routerLink="/category/sport">Sport</a>
+      <a routerLink="/category/business">Business</a>
     </nav>
 
     <div class="social-icons">

--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -1,7 +1,7 @@
 <div class="page">
   <app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
-  <h1 class="page-title">Vienna Local News</h1>
-  <app-top-stories [stories]="topStories"></app-top-stories>
+  <h1 class="page-title">{{pageTitle}}</h1>
+  <app-top-stories *ngIf="!tag" [stories]="topStories"></app-top-stories>
   <div class="pagination-controls">
     <label>
       Items per page:


### PR DESCRIPTION
## Summary
- add dedicated route for category pages
- make header logo link home and update nav links
- hide top stories when browsing a category
- add tag-based filtering in ViennaNews component

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_687dd5ae3a0c8329a311c21e52a4690b