### PR TITLE
Implement category pages and simplified nav

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { NewsService } from './services/news.service';
 import { NewsCardComponent } from './components/news-card/news-card.component';
 import { TopStoriesComponent } from './components/top-stories/top-stories.component';
 import { ViennaNewsComponent } from './components/vienna-news/vienna-news.component';
+import { TaggedNewsComponent } from './components/tagged-news/tagged-news.component';
 import { WeatherComponent } from './components/weather/weather.component';
 import { MailmanLoaderComponent } from './components/mailman-loader/mailman-loader.component';
 import { CookieBannerComponent } from './components/cookie-banner/cookie-banner.component';
@@ -29,6 +30,7 @@ import { CookiePolicyComponent } from './components/cookie-policy/cookie-policy.
     NewsCardComponent,
     TopStoriesComponent,
     ViennaNewsComponent,
+    TaggedNewsComponent,
     WeatherComponent,
     MailmanLoaderComponent,
     CookieBannerComponent,
@@ -43,8 +45,14 @@ import { CookiePolicyComponent } from './components/cookie-policy/cookie-policy.
     AngularFirestoreModule,
     RouterModule.forRoot([
       { path: '',component: ViennaNewsComponent, pathMatch: 'full' },
+      { path: 'region', component: TaggedNewsComponent, data: { tag: 'region' } },
+      { path: 'sport', component: TaggedNewsComponent, data: { tag: 'sport' } },
+      { path: 'business', component: TaggedNewsComponent, data: { tag: 'business' } },
       { path: 'cookie-settings', component: CookieSettingsComponent },
       { path: 'cookie-policy', component: CookiePolicyComponent },
+      { path: 'region/:id', component: NewsDetailComponent },
+      { path: 'sport/:id', component: NewsDetailComponent },
+      { path: 'business/:id', component: NewsDetailComponent },
       { path: ':id', component: NewsDetailComponent }
     ])
   ],

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,6 +1,6 @@
 <header [class.hidden]="isHidden">
   <div class="top-bar">
-    <div class="branding">
+    <div class="branding" routerLink="/">
       <span class="logo" aria-hidden="true">
         <svg viewBox="0 0 24 24" width="24" height="24">
           <circle cx="12" cy="12" r="10" fill="currentColor" />
@@ -16,15 +16,9 @@
       <span></span>
     </button>
     <nav class="main-nav" [class.open]="isMenuOpen" (click)="closeMenu()">
-      <a href="#">Home</a>
-      <a href="#">Region</a>
-      <a href="#">Sports</a>
-      <a href="#">Business</a>
-      <a href="#">Culture</a>
-      <a href="#">Lifestyle</a>
-      <a href="#">Tech</a>
-      <a href="#">Opinion</a>
-      <a routerLink="/local-news/vienna">Vienna</a>
+      <a routerLink="/region">Region</a>
+      <a routerLink="/sport">Sport</a>
+      <a routerLink="/business">Business</a>
     </nav>
 
     <div class="social-icons">

--- a/src/app/components/tagged-news/tagged-news.component.html
+++ b/src/app/components/tagged-news/tagged-news.component.html
@@ -1,0 +1,24 @@
+<div class="page">
+  <h1 class="page-title">{{ tag | titlecase }} News</h1>
+  <app-mailman-loader *ngIf="loading || error" [error]="error"></app-mailman-loader>
+  <div class="content-grid">
+    <div class="news-feed">
+      <app-news-card *ngFor="let n of feed" [article]="n" [baseRoute]="'/' + tag"></app-news-card>
+      <div class="pagination-controls" *ngIf="feed.length">
+        <label>Items per page:
+          <select [ngModel]="itemsPerPage" (ngModelChange)="onPerPageChange($event)">
+            <option *ngFor="let opt of itemsPerPageOptions" [value]="opt">{{opt}}</option>
+          </select>
+        </label>
+        <button (click)="prevPage()" [disabled]="currentPage === 1">Prev</button>
+        <span>Page {{currentPage}} / {{totalPages}}</span>
+        <button (click)="nextPage()" [disabled]="currentPage === totalPages">Next</button>
+      </div>
+    </div>
+    <aside class="sidebar">
+      <div class="weather-widget">
+          <app-weather></app-weather>
+      </div>
+    </aside>
+  </div>
+</div>

--- a/src/app/components/tagged-news/tagged-news.component.scss
+++ b/src/app/components/tagged-news/tagged-news.component.scss
@@ -1,0 +1,56 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+.page {
+  font-family: 'Inter', sans-serif;
+  background: #f8f9fa;
+  color: #212529;
+  padding: 1rem;
+}
+
+.page-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: #d62828;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1rem;
+}
+
+.news-feed {
+  grid-column: span 8;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.sidebar {
+  grid-column: span 4;
+}
+
+.weather-widget {
+  background: #fff;
+  padding: 1rem;
+  border: 1px solid #dee2e6;
+  position: sticky;
+  top: 1rem;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+@media (max-width: 768px) {
+  .content-grid {
+    grid-template-columns: 1fr;
+  }
+  .news-feed, .sidebar {
+    grid-column: span 12;
+  }
+}

--- a/src/app/components/tagged-news/tagged-news.component.ts
+++ b/src/app/components/tagged-news/tagged-news.component.ts
@@ -1,0 +1,103 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { News, NewsService } from '../../services/news.service';
+import { first } from 'rxjs';
+
+@Component({
+  selector: 'app-tagged-news',
+  templateUrl: './tagged-news.component.html',
+  styleUrls: ['./tagged-news.component.scss']
+})
+export class TaggedNewsComponent implements OnInit {
+  tag = '';
+  feed: News[] = [];
+  loading = true;
+  error = false;
+
+  itemsPerPageOptions = [5, 10, 15, 30];
+  itemsPerPage = this.itemsPerPageOptions[1];
+  currentPage = 1;
+  pageCursors: (Date | null)[] = [null];
+  hasMore = false;
+  totalNewsCount = 0;
+  totalPages = 1;
+
+  constructor(private route: ActivatedRoute, private news: NewsService) {}
+
+  ngOnInit(): void {
+    this.tag = this.route.snapshot.data['tag'];
+    this.loadTotalNewsCount();
+    this.loadPage(1);
+  }
+
+  private loadTotalNewsCount() {
+    const cacheKey = `newsCount-${this.tag}`;
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      this.totalNewsCount = +cached;
+      this.updateTotalPages();
+    } else {
+      this.news
+        .getNewsCountByTag(this.tag)
+        .pipe(first())
+        .subscribe({
+          next: count => {
+            this.totalNewsCount = count;
+            localStorage.setItem(cacheKey, count.toString());
+            this.updateTotalPages();
+          },
+          error: () => (this.error = true)
+        });
+    }
+  }
+
+  private updateTotalPages() {
+    this.totalPages = Math.max(1, Math.ceil(this.totalNewsCount / this.itemsPerPage));
+    this.hasMore = this.currentPage < this.totalPages;
+  }
+
+  private loadPage(page: number) {
+    const cursor = this.pageCursors[page - 1] ?? null;
+    this.loading = true;
+    this.news
+      .getNewsPageByTag(this.tag, this.itemsPerPage, cursor)
+      .pipe(first())
+      .subscribe({
+        next: list => {
+          this.feed = list;
+          this.currentPage = page;
+          this.updateTotalPages();
+          const last = list[list.length - 1];
+          if (last) {
+            this.pageCursors[page] = last.created_at;
+          }
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+          this.error = true;
+        }
+      });
+  }
+
+
+  nextPage(): void {
+    if (this.hasMore) {
+      this.loadPage(this.currentPage + 1);
+    }
+  }
+
+  prevPage(): void {
+    if (this.currentPage > 1) {
+      this.loadPage(this.currentPage - 1);
+    }
+  }
+
+  onPerPageChange(val: number) {
+    this.itemsPerPage = val;
+    this.updateTotalPages();
+    this.currentPage = 1;
+    this.pageCursors = [null];
+    this.loadPage(1);
+  }
+}

--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -61,6 +61,26 @@ export class NewsService {
       .pipe(map(list => list.map(n => this.normalizeArticle(n))));
   }
 
+  getNewsPageByTag(
+    tag: string,
+    pageSize: number,
+    startAfterDate: Date | null
+  ): Observable<News[]> {
+    return this.firestore
+      .collection<News>('news', ref => {
+        let query = ref
+          .where('tag', '==', tag)
+          .orderBy('created_at', 'desc')
+          .limit(pageSize);
+        if (startAfterDate) {
+          query = query.startAfter(startAfterDate);
+        }
+        return query;
+      })
+      .valueChanges({ idField: 'id' })
+      .pipe(map(list => list.map(n => this.normalizeArticle(n))));
+  }
+
   getNewsById(id: string): Observable<News> {
     return this.firestore
       .collection<News>('news')
@@ -72,6 +92,13 @@ export class NewsService {
   getNewsCount(): Observable<number> {
     return this.firestore
       .collection<News>('news')
+      .get()
+      .pipe(map(snapshot => snapshot.size));
+  }
+
+  getNewsCountByTag(tag: string): Observable<number> {
+    return this.firestore
+      .collection<News>('news', ref => ref.where('tag', '==', tag))
       .get()
       .pipe(map(snapshot => snapshot.size));
   }


### PR DESCRIPTION
## Summary
- add generic TaggedNewsComponent for region/sport/business pages
- limit navbar links to Region, Sport and Business
- hook navigation title to home page
- add routes for new category pages
- extend `NewsService` to filter news by tag

## Testing
- `npm run build`
- `npm test` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_687dda10f01483298ae5e15e2feb3848