### PR TITLE
Implement mailman walking cycle

### DIFF
--- a/src/app/components/mailman-loader/mailman-loader.component.html
+++ b/src/app/components/mailman-loader/mailman-loader.component.html
@@ -1,14 +1,88 @@
 <div class="mailman-wrapper" [class.error]="error">
-    <svg class="mailman" viewBox="0 0 64 64">
-        <rect class="left-leg" x="24" y="36" width="4" height="14" fill="#447ab4" />
-        <rect class="right-leg" x="36" y="36" width="4" height="14" fill="#447ab4" />
-        <rect x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
-        <path d="M24 28h-6v8h6z" fill="#8d6e63" />
-        <circle cx="32" cy="14" r="6" fill="#a67c52" />
-        <rect x="28" y="8" width="8" height="3" fill="#447ab4" />
-    </svg>
-    <div class="letter" *ngIf="error"></div>
-    <p class="error-message" *ngIf="error">
-        Oops! The news couldn't be delivered. Please try again.
-    </p>
+  <svg class="mailman" viewBox="0 0 64 64">
+    <g class="pose pose-1">
+      <rect class="left-leg" x="22" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="36" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="16" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="42" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="46" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-2">
+      <rect class="left-leg" x="24" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="34" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="18" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="40" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="44" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-3">
+      <rect class="left-leg" x="26" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="32" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="20" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="38" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="42" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-4">
+      <rect class="left-leg" x="28" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="30" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="22" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="36" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="40" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-5">
+      <rect class="left-leg" x="36" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="22" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="42" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="16" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="20" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-6">
+      <rect class="left-leg" x="34" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="24" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="40" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="18" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="22" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-7">
+      <rect class="left-leg" x="32" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="26" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="38" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="20" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="24" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+    <g class="pose pose-8">
+      <rect class="left-leg" x="30" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="right-leg" x="28" y="36" width="4" height="14" fill="#447ab4" />
+      <rect class="left-arm" x="36" y="28" width="4" height="10" fill="#8d6e63" />
+      <rect class="right-arm" x="22" y="26" width="4" height="10" fill="#8d6e63" />
+      <rect class="envelope" x="26" y="30" width="6" height="4" fill="#fff" stroke="#999" />
+      <rect class="body" x="26" y="22" width="12" height="16" rx="2" fill="#5975a1" />
+      <circle class="head" cx="32" cy="14" r="6" fill="#a67c52" />
+      <rect class="cap" x="28" y="8" width="8" height="3" fill="#447ab4" />
+    </g>
+  </svg>
+  <div class="letter" *ngIf="error"></div>
+  <p class="error-message" *ngIf="error">
+    Oops! The news couldn't be delivered. Please try again.
+  </p>
 </div>

--- a/src/app/components/mailman-loader/mailman-loader.component.scss
+++ b/src/app/components/mailman-loader/mailman-loader.component.scss
@@ -6,27 +6,15 @@
   margin: 4vmin auto;
 }
 
+
 .mailman {
   width: 100%;
   height: 100%;
   position: absolute;
   bottom: 0;
-  animation: walk 6s linear infinite;
+  animation: walk 8s linear infinite;
 }
 
-.left-leg,
-.right-leg {
-  transform-box: fill-box;
-  transform-origin: 50% 0%;
-}
-
-.left-leg {
-  animation: left-swing 1s ease-in-out infinite;
-}
-
-.right-leg {
-  animation: right-swing 1s ease-in-out infinite;
-}
 
 .letter {
   position: absolute;
@@ -48,6 +36,28 @@
   animation: drop 2s ease-in-out infinite;
 }
 
+.pose {
+  opacity: 0;
+  animation: pose-cycle 8s steps(1) infinite;
+}
+
+.pose-1 { animation-delay: 0s; }
+.pose-2 { animation-delay: -1s; }
+.pose-3 { animation-delay: -2s; }
+.pose-4 { animation-delay: -3s; }
+.pose-5 { animation-delay: -4s; }
+.pose-6 { animation-delay: -5s; }
+.pose-7 { animation-delay: -6s; }
+.pose-8 { animation-delay: -7s; }
+
+.error .pose {
+  animation-play-state: paused;
+}
+
+.error .envelope {
+  display: none;
+}
+
 .error-message {
   text-align: center;
   font-size: 0.9rem;
@@ -64,18 +74,10 @@
   100% { transform: translate(-10vmin, 10vmin); opacity: 0; }
 }
 
-@keyframes left-swing {
-  0% { transform: rotate(20deg); }
-  25% { transform: rotate(0deg); }
-  50% { transform: rotate(-20deg); }
-  75% { transform: rotate(0deg); }
-  100% { transform: rotate(20deg); }
+@keyframes pose-cycle {
+  0% { opacity: 1; }
+  12.5% { opacity: 1; }
+  12.6% { opacity: 0; }
+  100% { opacity: 0; }
 }
 
-@keyframes right-swing {
-  0% { transform: rotate(-20deg); }
-  25% { transform: rotate(0deg); }
-  50% { transform: rotate(20deg); }
-  75% { transform: rotate(0deg); }
-  100% { transform: rotate(-20deg); }
-}


### PR DESCRIPTION
## Summary
- replace mailman loader SVG with eight stepped poses
- update styles to cycle through poses and freeze when errors occur

## Testing
- `npm test --silent` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_687e0d2f537083298603d5681e25e97f