### PR TITLE
Fix pagination alignment

### DIFF
--- a/src/app/components/tagged-news/tagged-news.component.html
+++ b/src/app/components/tagged-news/tagged-news.component.html
@@ -4,12 +4,13 @@
   <div class="content-grid">
     <div class="news-feed">
       <app-news-card *ngFor="let n of feed" [article]="n" [baseRoute]="'/' + tag"></app-news-card>
+      <div class="per-page" *ngIf="feed.length">
+        <label for="perPageSelect">Items per page:</label>
+        <select id="perPageSelect" [ngModel]="itemsPerPage" (ngModelChange)="onPerPageChange($event)">
+          <option *ngFor="let opt of itemsPerPageOptions" [value]="opt">{{opt}}</option>
+        </select>
+      </div>
       <div class="pagination-controls" *ngIf="feed.length">
-        <label>Items per page:
-          <select [ngModel]="itemsPerPage" (ngModelChange)="onPerPageChange($event)">
-            <option *ngFor="let opt of itemsPerPageOptions" [value]="opt">{{opt}}</option>
-          </select>
-        </label>
         <button (click)="prevPage()" [disabled]="currentPage === 1">Prev</button>
         <span>Page {{currentPage}} / {{totalPages}}</span>
         <button (click)="nextPage()" [disabled]="currentPage === totalPages">Next</button>

--- a/src/app/components/tagged-news/tagged-news.component.scss
+++ b/src/app/components/tagged-news/tagged-news.component.scss
@@ -46,6 +46,23 @@
   margin: 1rem 0;
 }
 
+.per-page {
+  margin: 0.5rem 0 1rem;
+  text-align: center;
+
+  label {
+    margin-right: 0.25rem;
+  }
+
+  select {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-primary);
+    border-radius: 4px;
+    background: var(--color-surface);
+    color: var(--text-primary);
+  }
+}
+
 @media (max-width: 768px) {
   .content-grid {
     grid-template-columns: 1fr;

--- a/src/app/components/vienna-news/vienna-news.component.html
+++ b/src/app/components/vienna-news/vienna-news.component.html
@@ -6,16 +6,16 @@
   <div class="content-grid">
     <div class="news-feed">
       <app-news-card *ngFor="let n of feed" [article]="n"></app-news-card>
-      <div class="pagination-controls" *ngIf="feed.length">
-        <button (click)="prevPage()" [disabled]="currentPage === 1">Prev</button>
-        <span>Page {{currentPage}} / {{totalPages}}</span>
-        <button (click)="nextPage()" [disabled]="currentPage === totalPages">Next</button>
-      </div>
       <div class="per-page" *ngIf="feed.length">
         <label for="perPageSelect">Items per page:</label>
         <select id="perPageSelect" [ngModel]="itemsPerPage" (ngModelChange)="onPerPageChange($event)">
           <option *ngFor="let opt of itemsPerPageOptions" [value]="opt">{{opt}}</option>
         </select>
+      </div>
+      <div class="pagination-controls" *ngIf="feed.length">
+        <button (click)="prevPage()" [disabled]="currentPage === 1">Prev</button>
+        <span>Page {{currentPage}} / {{totalPages}}</span>
+        <button (click)="nextPage()" [disabled]="currentPage === totalPages">Next</button>
       </div>
     </div>
     <aside class="sidebar">


### PR DESCRIPTION
## Summary
- reorder pagination sections in ViennaNews
- separate per-page controls from pagination in TaggedNews
- style new per-page block

## Testing
- `npm test` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881397aa3c0832992adc78953070905