### PR TITLE
Add dark theme toggle with persistent preference

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -44,6 +44,10 @@
       </a>
     </div>
 
+    <button class="theme-toggle" type="button" [attr.aria-label]="isDarkTheme ? 'Switch to light theme' : 'Switch to dark theme'" (click)="toggleTheme()">
+      <span aria-hidden="true">{{ isDarkTheme ? '☀️' : '🌙' }}</span>
+    </button>
+
     <div class="search-container">
       <button class="search-btn" aria-label="Search" (click)="toggleSearch()">
         <svg viewBox="0 0 24 24" width="20" height="20">

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -77,6 +77,21 @@ header {
 }
 
 
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--color-surface);
+  color: var(--color-surface);
+  border-radius: 999px;
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+  margin-left: 0.75rem;
+}
+
+.theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
 .search-btn {
   background: transparent;
   border: none;

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,5 +1,7 @@
 import { Component, HostListener } from '@angular/core';
 
+type ThemeMode = 'light' | 'dark';
+
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
@@ -11,7 +13,12 @@ export class HeaderComponent {
   showSearch = false;
   searchTerm = '';
   suggestions: string[] = [];
+  isDarkTheme = false;
   private lastScrollY = 0;
+
+  constructor() {
+    this.initializeTheme();
+  }
 
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
@@ -32,6 +39,25 @@ export class HeaderComponent {
   onSearch(value: string): void {
     this.searchTerm = value;
     this.updateSuggestions();
+  }
+
+  toggleTheme(): void {
+    this.isDarkTheme = !this.isDarkTheme;
+    this.applyTheme(this.isDarkTheme ? 'dark' : 'light');
+  }
+
+  private initializeTheme(): void {
+    const storedTheme = localStorage.getItem('theme') as ThemeMode | null;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = storedTheme ?? (prefersDark ? 'dark' : 'light');
+
+    this.isDarkTheme = theme === 'dark';
+    this.applyTheme(theme);
+  }
+
+  private applyTheme(theme: ThemeMode): void {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
   }
 
   private updateSuggestions(): void {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,6 +10,16 @@
   --tile-image-height: 7.5rem;
 }
 
+:root[data-theme='dark'] {
+  --color-primary: #111827;
+  --color-secondary: #60a5fa;
+  --color-accent: #f59e0b;
+  --color-background: #030712;
+  --color-surface: #1f2937;
+  --text-primary: #f3f4f6;
+  --text-muted: #d1d5db;
+}
+
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 
 body {
@@ -18,6 +28,7 @@ body {
   padding: 0;
   background-color: var(--color-background);
   color: var(--text-primary);
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 header, footer {


### PR DESCRIPTION
### Motivation
- Provide users with a light/dark theme switch so the site can adapt to user preference and system settings.
- Persist the selected theme across sessions so the UI remains consistent between visits.
- Enable CSS variable overrides so the entire app can switch colors without rewiring component styles.

### Description
- Added a theme toggle button in the header UI (`src/app/components/header/header.component.html`) that displays a sun/moon icon and an accessible label bound to the current state.
- Implemented theme state and handlers in the header component (`src/app/components/header/header.component.ts`) including `isDarkTheme`, `toggleTheme()`, `initializeTheme()`, and `applyTheme()` which writes `data-theme` on `<html>` and uses `localStorage` for persistence.
- Added styling for the theme toggle control (`src/app/components/header/header.component.scss`) to match the header appearance and hover state.
- Introduced dark-mode CSS variable overrides and smooth color transitions in the global stylesheet (`src/styles.scss`) using `:root[data-theme='dark']` so components pick up dark values automatically.

### Testing
- Ran `npm run build` which completed successfully (build warnings are non-blocking and unchanged).
- Launched the dev server and executed an automated Playwright script that opened the page and clicked the theme toggle, producing a screenshot artifact showing the dark theme toggle action completed.
- Verified that `localStorage` is written with the chosen `theme` and that `data-theme` is applied to the document element during initialization and after toggles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b3ed33048329817c4b6ab6382176)