### PR TITLE
Fix Firestore FieldValue undefined error when opening news detail

### DIFF
--- a/src/app/services/news.service.ts
+++ b/src/app/services/news.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import firebase from 'firebase/compat/app';
+import 'firebase/compat/firestore';
 import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 


### PR DESCRIPTION
### Motivation
- Clicking a single news item caused a runtime `TypeError: Cannot read properties of undefined (reading 'FieldValue')` because `firebase.firestore.FieldValue` from the compat layer was not initialized before use.

### Description
- Add the Firestore compat side-effect import `import 'firebase/compat/firestore';` to `src/app/services/news.service.ts` so `firebase.firestore.FieldValue.increment(1)` is available at runtime.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b48f29a48329af3e2169e04801e5)